### PR TITLE
Fixed point

### DIFF
--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -1,0 +1,290 @@
+#if ! defined(_SG14_FIXED_POINT)
+#define _SG14_FIXED_POINT 1
+
+#include <climits>
+#include <cmath>
+#include <cinttypes>
+#include <limits>
+#include <type_traits>
+
+namespace sg14
+{
+	////////////////////////////////////////////////////////////////////////////////
+	// forward-declarations
+
+	namespace _impl
+	{
+		// given an integral (except bool) type T, provides the member typedef type
+		// which is the next longest sized integer type corresponding to T
+		template <typename INT_TYPE>
+		struct next_size;
+
+		template <typename T>
+		using next_size_t = typename next_size<T>::type;
+
+		// performs a shift operation by a fixed number of bits avoiding two pitfalls:
+		// 1) shifting by a negative amount causes undefined behavior
+		// 2) converting between integer types of different sizes can lose significant bits during shift right
+		template <int EXPONENT, typename OUTPUT, typename INPUT, typename std::enable_if<EXPONENT >= 0 && sizeof(OUTPUT) <= sizeof(INPUT), int>::type dummy = 0>
+		constexpr OUTPUT shift_left(INPUT i) noexcept
+		{
+			static_assert(std::is_integral<INPUT>::value, "INPUT must be integral type");
+			static_assert(std::is_integral<OUTPUT>::value, "OUTPUT must be integral type");
+			return static_cast<OUTPUT>(i) << EXPONENT;
+		}
+
+		template <int EXPONENT, typename OUTPUT, typename INPUT, typename std::enable_if<EXPONENT >= 0 && ! (sizeof(OUTPUT) <= sizeof(INPUT)), char>::type dummy = 0>
+		constexpr OUTPUT shift_left(INPUT i) noexcept
+		{
+			static_assert(std::is_integral<INPUT>::value, "INPUT must be integral type");
+			static_assert(std::is_integral<OUTPUT>::value, "OUTPUT must be integral type");
+			return static_cast<OUTPUT>(i << EXPONENT);
+		}
+
+		template <int EXPONENT, typename OUTPUT, typename INPUT, typename std::enable_if<EXPONENT >= 0 && sizeof(OUTPUT) <= sizeof(INPUT), int>::type dummy = 0>
+		constexpr OUTPUT shift_right(INPUT i) noexcept
+		{
+			static_assert(std::is_integral<INPUT>::value, "INPUT must be integral type");
+			static_assert(std::is_integral<OUTPUT>::value, "OUTPUT must be integral type");
+			return static_cast<OUTPUT>(i >> EXPONENT);
+		}
+
+		template <int EXPONENT, typename OUTPUT, typename INPUT, typename std::enable_if<EXPONENT >= 0 && !(sizeof(OUTPUT) <= sizeof(INPUT)), char>::type dummy = 0>
+		constexpr OUTPUT shift_right(INPUT i) noexcept
+		{
+			static_assert(std::is_integral<INPUT>::value, "INPUT must be integral type");
+			static_assert(std::is_integral<OUTPUT>::value, "OUTPUT must be integral type");
+			return static_cast<OUTPUT>(i) >> EXPONENT;
+		}
+
+		template <int EXPONENT, typename OUTPUT, typename INPUT, typename std::enable_if<(EXPONENT < 0), int>::type dummy = 0>
+		constexpr OUTPUT shift_left(INPUT i) noexcept
+		{
+			return shift_right<-EXPONENT, OUTPUT, INPUT>(i);
+		}
+
+		template <int EXPONENT, typename OUTPUT, typename INPUT, typename std::enable_if<EXPONENT < 0, int>::type dummy = 0>
+		constexpr OUTPUT shift_right(INPUT i) noexcept
+		{
+			return shift_left<-EXPONENT, OUTPUT, INPUT>(i);
+		}
+
+		// returns given power of 2
+		template <typename S, int EXPONENT, typename std::enable_if<EXPONENT == 0, int>::type dummy = 0>
+		constexpr S pow2() noexcept
+		{
+			static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
+			return 1;
+		}
+
+		template <typename S, int EXPONENT, typename std::enable_if<!(EXPONENT <= 0), int>::type dummy = 0>
+		constexpr S pow2() noexcept
+		{
+			static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
+			return pow2<S, EXPONENT - 1>() * S(2);
+		}
+
+		template <typename S, int EXPONENT, typename std::enable_if<!(EXPONENT >= 0), int>::type dummy = 0>
+		constexpr S pow2() noexcept
+		{
+			static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
+			return pow2<S, EXPONENT + 1>() * S(.5);
+		}
+	}
+
+	template <typename REPR_TYPE, int EXPONENT>
+	class fixed_point;
+
+	// fixed-point type capable of storing values in the range [0, 1);
+	// a bit more precise than closed_unit
+	template <typename REPR_TYPE>
+	using open_unit = fixed_point<REPR_TYPE, - static_cast<int>(sizeof(REPR_TYPE)) * CHAR_BIT>;
+
+	// fixed-point type capable of storing values in the range [0, 1];
+	// actually storing values in the range [0, 2);
+	// a bit less precise than closed_unit
+	template <typename REPR_TYPE>
+	using closed_unit = fixed_point<
+		typename std::enable_if<std::is_unsigned<REPR_TYPE>::value, REPR_TYPE>::type,
+		1 - static_cast<int>(sizeof(REPR_TYPE)) * CHAR_BIT>;
+
+	////////////////////////////////////////////////////////////////////////////////
+	// fixed_point class template definition
+	//
+	// approximates a real number using a machine word - much like a floating-point
+	// number but - with exponent determined at run-time
+	//
+	// TODO: negative values, tests
+
+	template <typename REPR_TYPE, int EXPONENT = 0>
+	class fixed_point
+	{
+	public:
+		////////////////////////////////////////////////////////////////////////////////
+		// types
+
+		using repr_type = REPR_TYPE;
+
+		////////////////////////////////////////////////////////////////////////////////
+		// constants
+
+		constexpr static int exponent = EXPONENT;
+		constexpr static repr_type repr_max = std::numeric_limits<repr_type>::max();
+		constexpr static std::size_t repr_size = sizeof(repr_type);
+		constexpr static std::size_t repr_num_bits = repr_size * CHAR_BIT;
+
+		////////////////////////////////////////////////////////////////////////////////
+		// functions
+
+	private:
+		// constructor taking represenation explicitly using operator++(int)-style trick
+		constexpr fixed_point(repr_type repr, int) noexcept
+			: _repr(repr)
+		{
+		}
+	public:
+		constexpr fixed_point() noexcept {}
+
+		template <typename S, typename std::enable_if<std::is_integral<S>::value, int>::type dummy = 0>
+		constexpr fixed_point(S s) noexcept
+			: _repr(int_to_repr(s))
+		{
+		}
+
+		template <typename S, typename std::enable_if<std::is_floating_point<S>::value, int>::type dummy = 0>
+		constexpr fixed_point(S s) noexcept
+			: _repr(float_to_repr(s))
+		{
+		}
+
+		// returns value represented as a floating-point
+		template <typename S, typename std::enable_if<std::is_integral<S>::value, int>::type dummy = 0>
+		constexpr S get() const noexcept
+		{
+			return repr_to_int<S>(_repr);
+		}
+
+		// returns value represented as integral
+		template <typename S, typename std::enable_if<std::is_floating_point<S>::value, int>::type dummy = 0>
+		constexpr S get() const noexcept
+		{
+			return repr_to_float<S>(_repr);
+		}
+
+		// returns internal representation of value
+		constexpr repr_type data() const noexcept
+		{
+			return _repr;
+		}
+
+		// creates an instance given the underlying representation value
+		// TODO: constexpr with c++14?
+		static constexpr fixed_point from_data(repr_type repr) noexcept
+		{
+			return fixed_point(repr, 0);
+		}
+
+	private:
+		template <typename S, typename std::enable_if<std::is_floating_point<S>::value, int>::type dummy = 0>
+		static constexpr S one() noexcept
+		{
+			return _impl::pow2<S, - exponent>();
+		}
+
+		template <typename S, typename std::enable_if<std::is_integral<S>::value, int>::type dummy = 0>
+		static constexpr S one() noexcept
+		{
+			return int_to_repr<S>(1);
+		}
+
+		template <typename S>
+		static constexpr S inverse_one() noexcept
+		{
+			static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
+			return _impl::pow2<S, exponent>();
+		}
+
+		template <typename S>
+		static constexpr repr_type int_to_repr(S s) noexcept
+		{
+			static_assert(std::is_integral<S>::value, "S must be unsigned integral type");
+
+			return _impl::shift_right<exponent, repr_type>(s);
+		}
+
+		template <typename S>
+		static constexpr S repr_to_int(repr_type r) noexcept
+		{
+			static_assert(std::is_integral<S>::value, "S must be unsigned integral type");
+
+			return _impl::shift_left<exponent, S>(r);
+		}
+
+		template <typename S>
+		static constexpr repr_type float_to_repr(S s) noexcept
+		{
+			static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
+			return static_cast<repr_type>(s * one<S>());
+		}
+
+		template <typename S>
+		static constexpr S repr_to_float(repr_type r) noexcept
+		{
+			static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
+			return S(r) * inverse_one<S>();
+		}
+
+		////////////////////////////////////////////////////////////////////////////////
+		// variables
+
+		repr_type _repr = 0;
+	};
+
+	////////////////////////////////////////////////////////////////////////////////
+	// helper definitions
+
+	namespace _impl
+	{
+		// specializations of next_size<>
+		template <> struct next_size<std::uint8_t> { using type = std::uint16_t; };
+		template <> struct next_size<std::uint16_t> { using type = std::uint32_t; };
+		template <> struct next_size<std::uint32_t> { using type = std::uint64_t; };
+
+		template <> struct next_size<std::int8_t> { using type = std::int16_t; };
+		template <> struct next_size<std::int16_t> { using type = std::int32_t; };
+		template <> struct next_size<std::int32_t> { using type = std::int64_t; };
+	}
+
+	// linear interpolation between two identical specializations of fixed_point
+	// given floatint-point `t` for which result is `from` when t==0 and `to` when t==1
+	template <typename REPR_TYPE, int EXPONENT, typename S, typename>
+	constexpr fixed_point<REPR_TYPE, EXPONENT> lerp(
+		fixed_point<REPR_TYPE, EXPONENT> from,
+		fixed_point<REPR_TYPE, EXPONENT> to,
+		S t)
+	{
+		using closed_unit = closed_unit<REPR_TYPE>;
+		return lerp<REPR_TYPE, EXPONENT>(from, to, closed_unit(t));
+	}
+
+	// linear interpolation between two identical specializations of fixed_point
+	// given closed_unit `t` for which result is `from` when t==0 and `to` when t==1
+	template <typename REPR_TYPE, int EXPONENT>
+	constexpr fixed_point<REPR_TYPE, EXPONENT> lerp(
+		fixed_point<REPR_TYPE, EXPONENT> from,
+		fixed_point<REPR_TYPE, EXPONENT> to,
+		closed_unit<typename std::make_unsigned<REPR_TYPE>::type> t)
+	{
+		using fixed_point = fixed_point<REPR_TYPE, EXPONENT>;
+		using repr_type = typename fixed_point::repr_type;
+		using next_repr_type = typename _impl::next_size_t<repr_type>;
+		using closed_unit = closed_unit<typename std::make_unsigned<REPR_TYPE>::type>;
+
+		return fixed_point::from_data(
+			_impl::shift_left<closed_unit::exponent, repr_type>(
+				(static_cast<next_repr_type>(from.data()) * (closed_unit(1).data() - t.data())) +
+				(static_cast<next_repr_type>(to.data()) * t.data())));
+	}
+}
+
+#endif	// defined(_SG14_FIXED_POINT)

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -1,0 +1,123 @@
+#include "fixed_point.h"
+
+using namespace sg14;
+
+////////////////////////////////////////////////////////////////////////////////
+// crag::core::_impl::shift_left
+
+static_assert(_impl::shift_left<8, std::uint16_t, std::uint16_t>(0x1234) == 0x3400, "crag::core::_impl::shift_left test failed");
+static_assert(_impl::shift_left<8, std::uint16_t, std::uint8_t>(0x12) == 0x1200, "crag::core::_impl::shift_left test failed");
+static_assert(_impl::shift_left<8, std::uint8_t, std::uint16_t>(0x1234) == 0x0, "crag::core::_impl::shift_left test failed");
+
+static_assert(_impl::shift_left<-8, std::uint16_t, std::uint16_t>(0x1234) == 0x12, "crag::core::_impl::shift_left test failed");
+static_assert(_impl::shift_left<-8, std::uint16_t, std::uint8_t>(0x12) == 0x0, "crag::core::_impl::shift_left test failed");
+static_assert(_impl::shift_left<-8, std::uint8_t, std::uint16_t>(0x1234) == 0x12, "crag::core::_impl::shift_left test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// crag::core::_impl::shift_right
+
+static_assert(_impl::shift_right<8, std::uint16_t, std::uint16_t>(0x1234) == 0x12, "crag::core::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, std::uint16_t, std::uint8_t>(0x12) == 0x0, "crag::core::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, std::uint8_t, std::uint16_t>(0x1234) == 0x12, "crag::core::_impl::shift_right test failed");
+
+static_assert(_impl::shift_right<-8, std::uint16_t, std::uint16_t>(0x1234) == 0x3400, "crag::core::_impl::shift_right test failed");
+static_assert(_impl::shift_right<-8, std::uint16_t, std::uint8_t>(0x12) == 0x1200, "crag::core::_impl::shift_right test failed");
+static_assert(_impl::shift_right<-8, std::uint8_t, std::uint16_t>(0x1234) == 0x0, "crag::core::_impl::shift_right test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// crag::core::_impl::pow2
+
+static_assert(_impl::pow2<float, 0>() == 1, "crag::core::_impl::pow2 test failed");
+static_assert(_impl::pow2<double, -1>() == .5, "crag::core::_impl::pow2 test failed");
+static_assert(_impl::pow2<long double, 1>() == 2, "crag::core::_impl::pow2 test failed");
+static_assert(_impl::pow2<float, -3>() == .125, "crag::core::_impl::pow2 test failed");
+static_assert(_impl::pow2<double, 7>() == 128, "crag::core::_impl::pow2 test failed");
+static_assert(_impl::pow2<long double, 10>() == 1024, "crag::core::_impl::pow2 test failed");
+static_assert(_impl::pow2<float, 20>() == 1048576, "crag::core::_impl::pow2 test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// crag::core::fixed_point
+
+template <typename T, int E> using fp = fixed_point<T, E>;
+
+template <int E> using fp_u8 = fixed_point<std::uint8_t, E>;
+template <int E> using fp_u16 = fixed_point<std::uint16_t, E>;
+template <int E> using fp_u32 = fixed_point<std::uint32_t, E>;
+template <int E> using fp_u64 = fixed_point<std::uint64_t, E>;
+
+template <int E> using fp_s8 = fixed_point<std::int8_t, E>;
+template <int E> using fp_s16 = fixed_point<std::int16_t, E>;
+template <int E> using fp_s32 = fixed_point<std::int32_t, E>;
+template <int E> using fp_s64 = fixed_point<std::int64_t, E>;
+
+// exponent == 0
+static_assert(fp_u8<0>(12.34f).get<float>() == 12.f, "crag::core::fixed_point test failed");
+static_assert(fp_u16<0>(12.34f).get<double>() == 12.f, "crag::core::fixed_point test failed");
+static_assert(fp_u32<0>(12.34f).get<long double>() == 12.f, "crag::core::fixed_point test failed");
+static_assert(fp_u64<0>(12.34f).get<float>() == 12.f, "crag::core::fixed_point test failed");
+
+static_assert(fp_s8<0>(-12.34f).get<double>() == -12.f, "crag::core::fixed_point test failed");
+static_assert(fp_s16<0>(-12.34f).get<long double>() == -12.f, "crag::core::fixed_point test failed");
+static_assert(fp_s32<0>(-12.34f).get<float>() == -12.f, "crag::core::fixed_point test failed");
+static_assert(fp_s64<0>(-12.34f).get<double>() == -12.f, "crag::core::fixed_point test failed");
+
+// exponent == -7
+static_assert(fp_u8<-7>(.125f).get<float>() == .125f, "crag::core::fixed_point test failed");
+static_assert(fp_u16<-7>(232.125f).get<float>() == 232.125f, "crag::core::fixed_point test failed");
+static_assert(fp_u32<-7>(232.125f).get<float>() == 232.125f, "crag::core::fixed_point test failed");
+static_assert(fp_u64<-7>(232.125f).get<float>() == 232.125f, "crag::core::fixed_point test failed");
+
+static_assert(fp_s8<-7>(.125f).get<float>() == .125f, "crag::core::fixed_point test failed");
+static_assert(fp_s16<-7>(123.125f).get<float>() == 123.125f, "crag::core::fixed_point test failed");
+static_assert(fp_s32<-7>(123.125f).get<float>() == 123.125f, "crag::core::fixed_point test failed");
+static_assert(fp_s64<-7>(123.125f).get<float>() == 123.125f, "crag::core::fixed_point test failed");
+
+static_assert(fp_u8<-7>(.125f).get<double>() == .125f, "crag::core::fixed_point test failed");
+static_assert(fp_u16<-7>(232.125f).get<long double>() == 232.125f, "crag::core::fixed_point test failed");
+static_assert(fp_u32<-7>(232.125f).get<double>() == 232.125f, "crag::core::fixed_point test failed");
+static_assert(fp_u64<-7>(232.125f).get<long double>() == 232.125f, "crag::core::fixed_point test failed");
+
+static_assert(fp_s8<-7>(1).get<long double>() != 1.f, "crag::core::fixed_point test failed");
+static_assert(fp_s8<-7>(.5).get<float>() == .5f, "crag::core::fixed_point test failed");
+static_assert(fp_s8<-7>(.125f).get<long double>() == .125f, "crag::core::fixed_point test failed");
+static_assert(fp_s16<-7>(123.125f).get<int>() == 123, "crag::core::fixed_point test failed");
+static_assert(fp_s32<-7>(123.125f).get<long double>() == 123.125f, "crag::core::fixed_point test failed");
+static_assert(fp_s64<-7>(123.125l).get<float>() == 123.125f, "crag::core::fixed_point test failed");
+
+// exponent == 16
+static_assert(fp_u8<16>(65536).get<float>() == 65536.f, "crag::core::fixed_point test failed");
+static_assert(fp_u16<16>(6553.).get<int>() == 0, "crag::core::fixed_point test failed");
+static_assert(fp_u32<16>(4294967296l).get<double>() == 4294967296.f, "crag::core::fixed_point test failed");
+static_assert(fp_u64<16>(1125895611875328l).get<double>() == 1125895611875328l, "crag::core::fixed_point test failed");
+
+static_assert(fp_s8<16>(-65536).get<float>() == -65536.f, "crag::core::fixed_point test failed");
+static_assert(fp_s16<16>(-6553.).get<int>() == 0, "crag::core::fixed_point test failed");
+static_assert(fp_s32<16>(-4294967296l).get<double>() == -4294967296.f, "crag::core::fixed_point test failed");
+static_assert(fp_s64<16>(-1125895611875328l).get<double>() == -1125895611875328l, "crag::core::fixed_point test failed");
+
+// closed_unit
+template <typename T> using cu = closed_unit<T>;
+static_assert(cu<std::uint8_t>(.5).get<double>() == .5, "crag::core::closed_unit test failed");
+static_assert(cu<std::uint16_t>(.125f).get<float>() == .125f, "crag::core::closed_unit test failed");
+static_assert(cu<std::uint16_t>(.640625l).get<float>() == .640625, "crag::core::closed_unit test failed");
+static_assert(cu<std::uint16_t>(1.640625).get<float>() == 1.640625f, "crag::core::closed_unit test failed");
+static_assert(cu<std::uint16_t>(1u).get<std::uint64_t>() == 1, "crag::core::closed_unit test failed");
+static_assert(cu<std::uint16_t>(2).get<float>() != 2, "crag::core::closed_unit test failed");	// out-of-range test
+
+// open_unit
+template <typename T> using ou = open_unit<T>;
+static_assert(ou<std::uint8_t>(.5).get<double>() == .5, "crag::core::closed_unit test failed");
+static_assert(ou<std::uint16_t>(.125f).get<float>() == .125f, "crag::core::closed_unit test failed");
+static_assert(ou<std::uint16_t>(.640625l).get<float>() == .640625, "crag::core::closed_unit test failed");
+static_assert(ou<std::uint16_t>(1).get<float>() == 0, "crag::core::closed_unit test failed");	// dropped bit
+
+////////////////////////////////////////////////////////////////////////////////
+// crag::core::lerp
+
+static_assert(lerp(fp_u8<-7>(1), fp_u8<-7>(0), .5).get<float>() == .5f, "crag::core::lerp test failed");
+static_assert(lerp(fp_u16<-7>(.125), fp_u16<-7>(.625), .5).get<float>() == .375f, "crag::core::lerp test failed");
+static_assert(lerp(fp_u32<-16>(42123.51323), fp_u32<-16>(432.9191), .812).get<unsigned>() == 8270, "crag::core::lerp test failed");
+
+static_assert(lerp(fp_s8<-6>(1), fp_s8<-6>(0), .5).get<float>() == .5f, "crag::core::lerp test failed");
+static_assert(lerp(fp_s16<-10>(.125), fp_s16<-10>(.625), .5).get<float>() == .375f, "crag::core::lerp test failed");
+static_assert(lerp(fp_s32<-6>(.125), fp_s32<-6>(.625), .25).get<float>() == .25f, "crag::core::lerp test failed");

--- a/VS2015/SG14/SG14/SG14.vcxproj
+++ b/VS2015/SG14/SG14/SG14.vcxproj
@@ -11,6 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\SG14\fixed_point.h" />
     <ClInclude Include="..\..\..\SG14\rolling_queue.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/VS2015/SG14/SG14/SG14.vcxproj.filters
+++ b/VS2015/SG14/SG14/SG14.vcxproj.filters
@@ -2,5 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClInclude Include="..\..\..\SG14\rolling_queue.h" />
+    <ClInclude Include="..\..\..\SG14\fixed_point.h" />
   </ItemGroup>
 </Project>

--- a/VS2015/SG14/SG14_test/SG14_test.vcxproj
+++ b/VS2015/SG14/SG14_test/SG14_test.vcxproj
@@ -80,6 +80,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\SG14_test\fixed_point_test.cpp" />
     <ClCompile Include="..\..\..\SG14_test\SG14_test.cpp" />
     <ClCompile Include="main.cpp" />
   </ItemGroup>

--- a/VS2015/SG14/SG14_test/SG14_test.vcxproj.filters
+++ b/VS2015/SG14/SG14_test/SG14_test.vcxproj.filters
@@ -17,6 +17,9 @@
     <ClCompile Include="..\..\..\SG14_test\SG14_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\SG14_test\fixed_point_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\SG14_test\SG14_test.h">

--- a/cmake/.gitignore
+++ b/cmake/.gitignore
@@ -1,0 +1,5 @@
+CMakeCache.txt
+CMakeFiles
+Makefile
+cmake_install.cmake
+sg14

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8.4)
+project(sg14)
+
+set(WARNING_FLAGS "-Wall -Wextra -Wfatal-errors -Werror")
+set(OPT_FLAGS "-fno-exceptions -fno-unwind-tables")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS} ${OPT_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG -fno-rtti -Ofast")
+set(CMAKE_EXE_LINKER_FLAGS "-g")
+
+set(SG14_SOURCE_DIRECTORY "../SG14")
+set(SG14_TEST_SOURCE_DIRECTORY "../SG14_test")
+
+set(SOURCE_FILES
+    main.cpp
+    ${SG14_TEST_SOURCE_DIRECTORY}/SG14_test.cpp
+    ${SG14_TEST_SOURCE_DIRECTORY}/fixed_point_test.cpp)
+
+add_executable(sg14 ${SOURCE_FILES})
+
+include_directories("${SG14_SOURCE_DIRECTORY}" "${SG14_TEST_SOURCE_DIRECTORY}")
+
+target_link_libraries(sg14)
+# "dl" "pthread" "stdc++" "m")
+

--- a/cmake/main.cpp
+++ b/cmake/main.cpp
@@ -1,0 +1,17 @@
+//
+//  main.cpp
+//  SG14_test
+//
+//  Created by Guy Davidson on 11/06/2015.
+//  Copyright (c) 2015 hatcat. All rights reserved.
+//
+
+#include <iostream>
+
+#include "SG14_test.h"
+
+int main(int /*argc*/, const char * /*argv*/[])
+{
+    sg14_test::rolling_queue_test();
+    return 0;
+}


### PR DESCRIPTION
Adds `class sg14::fixed_point<>` and related code as discussed [here](https://groups.google.com/a/isocpp.org/forum/#!topic/sg14/1w5eiJsyT2Q).

Also adds a new project folder, cmake, with a copy of XCode's main.cpp file. This runs the `rolling_queue` tests. It also compiles the static tests in SG14_test/fixed_point_test.cpp.

# TODO
- Arithmetic operators and other helper functions such as `min`/`max` would be the next major piece of work for `fixed_point<>`.
- It would be wise to consolidate the test harness source into a single file - instead of having three project-specific versions.
- Source file, fixed_point.cpp, can be added to VS and XCode projects

# NOTES
- The fixed_point.h and fixed_point_test.cpp files are copies of [this header file](https://github.com/johnmcfarlane/crag/blob/85e07f38e868f810eb953755a890030ac15a37d8/src/core/fixed_point.h) and [this source file](https://github.com/johnmcfarlane/crag/blob/03aea03c3b86438502192fcea467f977bb904c69/src/core/fixed_point.cpp) moved to a different namespace.
- New code requires c++11 features and should run under Clang 3.6, GCC 4.9 and VC2015
- Warning: No prior review has been performed on this code and it has seen very little use!

Thanks!
John McFarlane