### PR TITLE
Added features and fixes to fixed_point

### DIFF
--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -131,7 +131,7 @@ namespace sg14
 			static_assert(_impl::is_integral<INPUT>::value, "INPUT must be integral type");
 			static_assert(_impl::is_integral<OUTPUT>::value, "OUTPUT must be integral type");
 
-			return static_cast<OUTPUT>(i << EXPONENT);
+			return static_cast<OUTPUT>(i) << EXPONENT;
 		}
 
 		// EXPONENT >= 0 && sizeof(OUTPUT) > sizeof(INPUT) && is_signed<INPUT>
@@ -147,10 +147,10 @@ namespace sg14
 			static_assert(_impl::is_integral<INPUT>::value, "INPUT must be integral type");
 			static_assert(_impl::is_integral<OUTPUT>::value, "OUTPUT must be integral type");
 
-			using signed_type = typename std::make_signed<INPUT>::type;
+			using signed_type = typename std::make_signed<OUTPUT>::type;
 
 			return (i >= 0)
-				? static_cast<OUTPUT>(i << EXPONENT)
+				? static_cast<OUTPUT>(i) << EXPONENT
 				: static_cast<OUTPUT>(-(static_cast<signed_type>(-i) << EXPONENT));
 		}
 
@@ -284,7 +284,7 @@ namespace sg14
 		// c'tor taking a fixed-point type
 		template <typename FROM_REPR_TYPE, int FROM_EXPONENT>
 		constexpr fixed_point(fixed_point<FROM_REPR_TYPE, FROM_EXPONENT> const & rhs) noexcept
-			: _repr(_impl::shift_left<(FROM_EXPONENT - EXPONENT), repr_type>(rhs.data()))
+			: _repr(_impl::shift_right<(EXPONENT - FROM_EXPONENT), repr_type>(rhs.data()))
 		{
 		}
 

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -281,6 +281,13 @@ namespace sg14
 		{
 		}
 
+		// c'tor taking a fixed-point type
+		template <typename FROM_REPR_TYPE, int FROM_EXPONENT>
+		constexpr fixed_point(fixed_point<FROM_REPR_TYPE, FROM_EXPONENT> const & rhs) noexcept
+			: _repr(_impl::shift_left<(FROM_EXPONENT - EXPONENT), repr_type>(rhs.data()))
+		{
+		}
+
 		// returns value represented as a floating-point
 		template <typename S, typename std::enable_if<_impl::is_integral<S>::value, int>::type dummy = 0>
 		constexpr S get() const noexcept

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -26,13 +26,15 @@ namespace sg14
 
 		// specializations
 		template <> struct next_size<std::uint8_t> { using type = std::uint16_t; };
-		template <> struct next_size<std::uint16_t> { using type = std::uint32_t; };
-		template <> struct next_size<std::uint32_t> { using type = std::uint64_t; };
-		template <> struct next_size<std::uint64_t> { using type = unsigned __int128; };
-
 		template <> struct next_size<std::int8_t> { using type = std::int16_t; };
+
+		template <> struct next_size<std::uint16_t> { using type = std::uint32_t; };
 		template <> struct next_size<std::int16_t> { using type = std::int32_t; };
+
+		template <> struct next_size<std::uint32_t> { using type = std::uint64_t; };
 		template <> struct next_size<std::int32_t> { using type = std::int64_t; };
+
+		template <> struct next_size<std::uint64_t> { using type = unsigned __int128; };
 		template <> struct next_size<std::int64_t> { using type = __int128; };
 
 		////////////////////////////////////////////////////////////////////////////////

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -204,18 +204,18 @@ namespace sg14
 		// sg14::sqrt helper functions
 
 		template <typename REPR_TYPE>
-		constexpr next_size_t<REPR_TYPE> sqrt_bit(
+		constexpr REPR_TYPE sqrt_bit(
 			REPR_TYPE n,
-			next_size_t<REPR_TYPE> bit = next_size_t<REPR_TYPE>(1) << (sizeof(next_size_t<REPR_TYPE>) * CHAR_BIT - 2)) noexcept
+			REPR_TYPE bit = REPR_TYPE(1) << (sizeof(REPR_TYPE) * CHAR_BIT - 2)) noexcept
 		{
-			return (bit > n) ? sqrt_bit(n, bit >> 2) : bit;
+			return (bit > n) ? sqrt_bit<REPR_TYPE>(n, bit >> 2) : bit;
 		}
 
 		template <typename REPR_TYPE>
 		constexpr REPR_TYPE sqrt_solve3(
 			REPR_TYPE n,
-			next_size_t<REPR_TYPE> bit,
-			next_size_t<REPR_TYPE> result) noexcept
+			REPR_TYPE bit,
+			REPR_TYPE result) noexcept
 		{
 			return bit
 				   ? (n >= result + bit)
@@ -506,8 +506,10 @@ namespace sg14
 	template <typename REPR_TYPE, int EXPONENT>
 	constexpr fixed_point<REPR_TYPE, EXPONENT> sqrt(fixed_point<REPR_TYPE, EXPONENT> const & x) noexcept
 	{
-		static_assert(! EXPONENT, "only zero-exponent fixed_point specializations supported");
-		return fixed_point<REPR_TYPE, EXPONENT>::from_data(_impl::sqrt_solve1(x.data()));
+		return fixed_point<REPR_TYPE, EXPONENT>::from_data(
+			static_cast<REPR_TYPE>(
+				_impl::sqrt_solve1(
+					fixed_point<_impl::next_size_t<REPR_TYPE>, EXPONENT * 2>(x).data())));
 	}
 
 	////////////////////////////////////////////////////////////////////////////////

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -68,6 +68,52 @@ namespace sg14
 		struct is_integral : std::is_integral<T> { };
 
 		////////////////////////////////////////////////////////////////////////////////
+		// sg14::_impl::make_signed
+
+		template <typename T>
+		struct make_signed;
+
+#if defined(_SG14_FIXED_POINT_64)
+		template <>
+		struct make_signed<__int128>
+		{
+			using type = __int128;
+		};
+
+		template <>
+		struct make_signed<unsigned __int128>
+		{
+			using type = __int128;
+		};
+#endif
+
+		template <typename T>
+		struct make_signed : std::make_signed<T> { };
+
+		////////////////////////////////////////////////////////////////////////////////
+		// sg14::_impl::make_unsigned
+
+		template <typename T>
+		struct make_unsigned;
+
+#if defined(_SG14_FIXED_POINT_64)
+		template <>
+		struct make_unsigned<__int128>
+		{
+			using type = unsigned __int128;
+		};
+
+		template <>
+		struct make_unsigned<unsigned __int128>
+		{
+			using type = unsigned __int128;
+		};
+#endif
+
+		template <typename T>
+		struct make_unsigned : std::make_unsigned<T> { };
+
+		////////////////////////////////////////////////////////////////////////////////
 		// sg14::_impl::shift_left and sg14::_impl::shift_right
 
 		// performs a shift operation by a fixed number of bits avoiding two pitfalls:
@@ -103,7 +149,7 @@ namespace sg14
 			static_assert(_impl::is_integral<INPUT>::value, "INPUT must be integral type");
 			static_assert(_impl::is_integral<OUTPUT>::value, "OUTPUT must be integral type");
 
-			using signed_type = typename std::make_signed<OUTPUT>::type;
+			using signed_type = typename _impl::make_signed<OUTPUT>::type;
 
 			return (i >= 0)
 				? static_cast<OUTPUT>(i) << EXPONENT
@@ -147,7 +193,7 @@ namespace sg14
 			static_assert(_impl::is_integral<INPUT>::value, "INPUT must be integral type");
 			static_assert(_impl::is_integral<OUTPUT>::value, "OUTPUT must be integral type");
 
-			using signed_type = typename std::make_signed<OUTPUT>::type;
+			using signed_type = typename _impl::make_signed<OUTPUT>::type;
 
 			return (i >= 0)
 				? static_cast<OUTPUT>(i) << EXPONENT
@@ -476,12 +522,12 @@ namespace sg14
 	constexpr fixed_point<REPR_TYPE, EXPONENT> lerp(
 		fixed_point<REPR_TYPE, EXPONENT> from,
 		fixed_point<REPR_TYPE, EXPONENT> to,
-		closed_unit<typename std::make_unsigned<REPR_TYPE>::type> t)
+		closed_unit<typename _impl::make_unsigned<REPR_TYPE>::type> t)
 	{
 		using fixed_point = fixed_point<REPR_TYPE, EXPONENT>;
 		using repr_type = typename fixed_point::repr_type;
 		using next_repr_type = typename _impl::next_size<repr_type>::type;
-		using closed_unit = closed_unit<typename std::make_unsigned<REPR_TYPE>::type>;
+		using closed_unit = closed_unit<typename _impl::make_unsigned<REPR_TYPE>::type>;
 
 		return fixed_point::from_data(
 			_impl::shift_left<closed_unit::exponent, repr_type>(

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -274,7 +274,7 @@ namespace sg14
 		{
 		}
 
-		// c'tor taking an floating-point type
+		// c'tor taking a floating-point type
 		template <typename S, typename std::enable_if<std::is_floating_point<S>::value, int>::type dummy = 0>
 		constexpr fixed_point(S s) noexcept
 			: _repr(float_to_repr(s))

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -131,6 +131,8 @@ static_assert(fp_s8<1>(-5).get<int>() == -6, "sg14::fixed_point test failed");
 static_assert(fp_u8<-4>(fp_s16<-8>(1.5)).get<float>() == 1.5, "sg14::fixed_point test failed");
 static_assert(fp_u16<-8>(fp_s8<-4>(3.25)).get<float>() == 3.25, "sg14::fixed_point test failed");
 static_assert(fp_u8<4>(fp_s16<-4>(768)).get<int>() == 768, "sg14::fixed_point test failed");
+static_assert(fp_u64<-48>(fp_u32<-24>(3.141592654)).get<float>() > 3.1415923f, "sg14::fixed_point test failed");
+static_assert(fp_u64<-48>(fp_u32<-24>(3.141592654)).get<float>() < 3.1415927f, "sg14::fixed_point test failed");
 
 // closed_unit
 template <typename T> using cu = closed_unit<T>;

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -3,40 +3,49 @@
 using namespace sg14;
 
 ////////////////////////////////////////////////////////////////////////////////
-// crag::core::_impl::shift_left
-
-static_assert(_impl::shift_left<8, std::uint16_t, std::uint16_t>(0x1234) == 0x3400, "crag::core::_impl::shift_left test failed");
-static_assert(_impl::shift_left<8, std::uint16_t, std::uint8_t>(0x12) == 0x1200, "crag::core::_impl::shift_left test failed");
-static_assert(_impl::shift_left<8, std::uint8_t, std::uint16_t>(0x1234) == 0x0, "crag::core::_impl::shift_left test failed");
-
-static_assert(_impl::shift_left<-8, std::uint16_t, std::uint16_t>(0x1234) == 0x12, "crag::core::_impl::shift_left test failed");
-static_assert(_impl::shift_left<-8, std::uint16_t, std::uint8_t>(0x12) == 0x0, "crag::core::_impl::shift_left test failed");
-static_assert(_impl::shift_left<-8, std::uint8_t, std::uint16_t>(0x1234) == 0x12, "crag::core::_impl::shift_left test failed");
+////////////////////////////////////////////////////////////////////////////////
+// sg14::_impl
 
 ////////////////////////////////////////////////////////////////////////////////
-// crag::core::_impl::shift_right
+// sg14::_impl::shift_left/right positive RHS
 
-static_assert(_impl::shift_right<8, std::uint16_t, std::uint16_t>(0x1234) == 0x12, "crag::core::_impl::shift_right test failed");
-static_assert(_impl::shift_right<8, std::uint16_t, std::uint8_t>(0x12) == 0x0, "crag::core::_impl::shift_right test failed");
-static_assert(_impl::shift_right<8, std::uint8_t, std::uint16_t>(0x1234) == 0x12, "crag::core::_impl::shift_right test failed");
+static_assert(_impl::shift_left<8, std::uint16_t>((std::uint16_t)0x1234) == 0x3400, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<8, std::uint16_t>((std::uint8_t)0x1234) == 0x3400, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<8, std::uint8_t>((std::uint16_t)0x1234) == 0x0, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<8, std::int16_t>(-123) == -31488, "sg14::_impl::shift_left test failed");
 
-static_assert(_impl::shift_right<-8, std::uint16_t, std::uint16_t>(0x1234) == 0x3400, "crag::core::_impl::shift_right test failed");
-static_assert(_impl::shift_right<-8, std::uint16_t, std::uint8_t>(0x12) == 0x1200, "crag::core::_impl::shift_right test failed");
-static_assert(_impl::shift_right<-8, std::uint8_t, std::uint16_t>(0x1234) == 0x0, "crag::core::_impl::shift_right test failed");
-
-////////////////////////////////////////////////////////////////////////////////
-// crag::core::_impl::pow2
-
-static_assert(_impl::pow2<float, 0>() == 1, "crag::core::_impl::pow2 test failed");
-static_assert(_impl::pow2<double, -1>() == .5, "crag::core::_impl::pow2 test failed");
-static_assert(_impl::pow2<long double, 1>() == 2, "crag::core::_impl::pow2 test failed");
-static_assert(_impl::pow2<float, -3>() == .125, "crag::core::_impl::pow2 test failed");
-static_assert(_impl::pow2<double, 7>() == 128, "crag::core::_impl::pow2 test failed");
-static_assert(_impl::pow2<long double, 10>() == 1024, "crag::core::_impl::pow2 test failed");
-static_assert(_impl::pow2<float, 20>() == 1048576, "crag::core::_impl::pow2 test failed");
+static_assert(_impl::shift_right<8, std::uint16_t, std::uint16_t>(0x1234) == 0x12, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, std::uint16_t, std::uint8_t>(0x1234) == 0x0, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, std::uint8_t, std::uint16_t>(0x1234) == 0x12, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, std::int16_t>(-31488) == -123, "sg14::_impl::shift_right test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
-// crag::core::fixed_point
+// sg14::_impl::shift_left/right negative RHS
+
+static_assert(_impl::shift_right<-8, std::uint16_t>((std::uint16_t)0x1234) == 0x3400, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<-8, std::uint16_t>((std::uint8_t)0x1234) == 0x3400, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<-8, std::uint8_t>((std::uint16_t)0x1234) == 0x0, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<-8, std::int16_t>(-123) == -31488, "sg14::_impl::shift_right test failed");
+
+static_assert(_impl::shift_left<-8, std::uint16_t>((std::uint16_t)0x1234) == 0x12, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<-8, std::uint16_t>((std::uint8_t)0x1234) == 0x0, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<-8, std::uint8_t>((std::uint16_t)0x1234) == 0x12, "sg14::_impl::shift_left test failed");
+static_assert(_impl::shift_left<-8, std::int16_t>(-31488) == -123, "sg14::_impl::shift_right test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// sg14::_impl::pow2
+
+static_assert(_impl::pow2<float, 0>() == 1, "sg14::_impl::pow2 test failed");
+static_assert(_impl::pow2<double, -1>() == .5, "sg14::_impl::pow2 test failed");
+static_assert(_impl::pow2<long double, 1>() == 2, "sg14::_impl::pow2 test failed");
+static_assert(_impl::pow2<float, -3>() == .125, "sg14::_impl::pow2 test failed");
+static_assert(_impl::pow2<double, 7>() == 128, "sg14::_impl::pow2 test failed");
+static_assert(_impl::pow2<long double, 10>() == 1024, "sg14::_impl::pow2 test failed");
+static_assert(_impl::pow2<float, 20>() == 1048576, "sg14::_impl::pow2 test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+// sg14::fixed_point
 
 template <typename T, int E> using fp = fixed_point<T, E>;
 
@@ -50,74 +59,130 @@ template <int E> using fp_s16 = fixed_point<std::int16_t, E>;
 template <int E> using fp_s32 = fixed_point<std::int32_t, E>;
 template <int E> using fp_s64 = fixed_point<std::int64_t, E>;
 
-// exponent == 0
-static_assert(fp_u8<0>(12.34f).get<float>() == 12.f, "crag::core::fixed_point test failed");
-static_assert(fp_u16<0>(12.34f).get<double>() == 12.f, "crag::core::fixed_point test failed");
-static_assert(fp_u32<0>(12.34f).get<long double>() == 12.f, "crag::core::fixed_point test failed");
-static_assert(fp_u64<0>(12.34f).get<float>() == 12.f, "crag::core::fixed_point test failed");
+////////////////////////////////////////////////////////////////////////////////
+// conversion
 
-static_assert(fp_s8<0>(-12.34f).get<double>() == -12.f, "crag::core::fixed_point test failed");
-static_assert(fp_s16<0>(-12.34f).get<long double>() == -12.f, "crag::core::fixed_point test failed");
-static_assert(fp_s32<0>(-12.34f).get<float>() == -12.f, "crag::core::fixed_point test failed");
-static_assert(fp_s64<0>(-12.34f).get<double>() == -12.f, "crag::core::fixed_point test failed");
+// exponent == 0
+static_assert(fp_u8<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
+static_assert(fp_u16<0>(12.34f).get<double>() == 12.f, "sg14::fixed_point test failed");
+static_assert(fp_u32<0>(12.34f).get<long double>() == 12.f, "sg14::fixed_point test failed");
+static_assert(fp_u64<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
+
+static_assert(fp_s8<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
+static_assert(fp_s16<0>(-12.34f).get<long double>() == -12.f, "sg14::fixed_point test failed");
+static_assert(fp_s32<0>(-12.34f).get<float>() == -12.f, "sg14::fixed_point test failed");
+static_assert(fp_s64<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
+
+// exponent = -1
+static_assert(fp_u8<-1>(127.5).get<float>() == 127.5, "sg14::fixed_point test failed");
+
+static_assert(fp_s8<-1>(63.5).get<float>() == 63.5, "sg14::fixed_point test failed");
+static_assert(fp_s8<-1>(-63.5).get<float>() == -63.5, "sg14::fixed_point test failed");
 
 // exponent == -7
-static_assert(fp_u8<-7>(.125f).get<float>() == .125f, "crag::core::fixed_point test failed");
-static_assert(fp_u16<-7>(232.125f).get<float>() == 232.125f, "crag::core::fixed_point test failed");
-static_assert(fp_u32<-7>(232.125f).get<float>() == 232.125f, "crag::core::fixed_point test failed");
-static_assert(fp_u64<-7>(232.125f).get<float>() == 232.125f, "crag::core::fixed_point test failed");
+static_assert(fp_u8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
+static_assert(fp_u16<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fp_u32<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fp_u64<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
 
-static_assert(fp_s8<-7>(.125f).get<float>() == .125f, "crag::core::fixed_point test failed");
-static_assert(fp_s16<-7>(123.125f).get<float>() == 123.125f, "crag::core::fixed_point test failed");
-static_assert(fp_s32<-7>(123.125f).get<float>() == 123.125f, "crag::core::fixed_point test failed");
-static_assert(fp_s64<-7>(123.125f).get<float>() == 123.125f, "crag::core::fixed_point test failed");
+static_assert(fp_s8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
+static_assert(fp_s16<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(fp_s32<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(fp_s64<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
 
-static_assert(fp_u8<-7>(.125f).get<double>() == .125f, "crag::core::fixed_point test failed");
-static_assert(fp_u16<-7>(232.125f).get<long double>() == 232.125f, "crag::core::fixed_point test failed");
-static_assert(fp_u32<-7>(232.125f).get<double>() == 232.125f, "crag::core::fixed_point test failed");
-static_assert(fp_u64<-7>(232.125f).get<long double>() == 232.125f, "crag::core::fixed_point test failed");
+static_assert(fp_u8<-7>(.125f).get<double>() == .125f, "sg14::fixed_point test failed");
+static_assert(fp_u16<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fp_u32<-7>(232.125f).get<double>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fp_u64<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
 
-static_assert(fp_s8<-7>(1).get<long double>() != 1.f, "crag::core::fixed_point test failed");
-static_assert(fp_s8<-7>(.5).get<float>() == .5f, "crag::core::fixed_point test failed");
-static_assert(fp_s8<-7>(.125f).get<long double>() == .125f, "crag::core::fixed_point test failed");
-static_assert(fp_s16<-7>(123.125f).get<int>() == 123, "crag::core::fixed_point test failed");
-static_assert(fp_s32<-7>(123.125f).get<long double>() == 123.125f, "crag::core::fixed_point test failed");
-static_assert(fp_s64<-7>(123.125l).get<float>() == 123.125f, "crag::core::fixed_point test failed");
+static_assert(fp_s8<-7>(1).get<long double>() != 1.f, "sg14::fixed_point test failed");
+static_assert(fp_s8<-7>(.5).get<float>() == .5f, "sg14::fixed_point test failed");
+static_assert(fp_s8<-7>(.125f).get<long double>() == .125f, "sg14::fixed_point test failed");
+static_assert(fp_s16<-7>(123.125f).get<int>() == 123, "sg14::fixed_point test failed");
+static_assert(fp_s32<-7>(123.125f).get<long double>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(fp_s64<-7>(123.125l).get<float>() == 123.125f, "sg14::fixed_point test failed");
 
 // exponent == 16
-static_assert(fp_u8<16>(65536).get<float>() == 65536.f, "crag::core::fixed_point test failed");
-static_assert(fp_u16<16>(6553.).get<int>() == 0, "crag::core::fixed_point test failed");
-static_assert(fp_u32<16>(4294967296l).get<double>() == 4294967296.f, "crag::core::fixed_point test failed");
-static_assert(fp_u64<16>(1125895611875328l).get<double>() == 1125895611875328l, "crag::core::fixed_point test failed");
+static_assert(fp_u8<16>(65536).get<float>() == 65536.f, "sg14::fixed_point test failed");
+static_assert(fp_u16<16>(6553.).get<int>() == 0, "sg14::fixed_point test failed");
+static_assert(fp_u32<16>(4294967296l).get<double>() == 4294967296.f, "sg14::fixed_point test failed");
+static_assert(fp_u64<16>(1125895611875328l).get<double>() == 1125895611875328l, "sg14::fixed_point test failed");
 
-static_assert(fp_s8<16>(-65536).get<float>() == -65536.f, "crag::core::fixed_point test failed");
-static_assert(fp_s16<16>(-6553.).get<int>() == 0, "crag::core::fixed_point test failed");
-static_assert(fp_s32<16>(-4294967296l).get<double>() == -4294967296.f, "crag::core::fixed_point test failed");
-static_assert(fp_s64<16>(-1125895611875328l).get<double>() == -1125895611875328l, "crag::core::fixed_point test failed");
+static_assert(fp_s8<16>(-65536).get<float>() == -65536.f, "sg14::fixed_point test failed");
+static_assert(fp_s16<16>(-6553.).get<int>() == 0, "sg14::fixed_point test failed");
+static_assert(fp_s32<16>(-4294967296l).get<double>() == -4294967296.f, "sg14::fixed_point test failed");
+static_assert(fp_s64<16>(-1125895611875328l).get<double>() == -1125895611875328l, "sg14::fixed_point test failed");
+
+// exponent = 1
+static_assert(fp_u8<1>(510).get<int>() == 510, "sg14::fixed_point test failed");
+static_assert(fp_u8<1>(511).get<int>() == 510, "sg14::fixed_point test failed");
+static_assert(fp_s8<1>(123.5).get<float>() == 122, "sg14::fixed_point test failed");
+
+static_assert(fp_s8<1>(255).get<int>() == 254, "sg14::fixed_point test failed");
+static_assert(fp_s8<1>(254).get<int>() == 254, "sg14::fixed_point test failed");
+static_assert(fp_s8<1>(-5).get<int>() == -6, "sg14::fixed_point test failed");
 
 // closed_unit
 template <typename T> using cu = closed_unit<T>;
-static_assert(cu<std::uint8_t>(.5).get<double>() == .5, "crag::core::closed_unit test failed");
-static_assert(cu<std::uint16_t>(.125f).get<float>() == .125f, "crag::core::closed_unit test failed");
-static_assert(cu<std::uint16_t>(.640625l).get<float>() == .640625, "crag::core::closed_unit test failed");
-static_assert(cu<std::uint16_t>(1.640625).get<float>() == 1.640625f, "crag::core::closed_unit test failed");
-static_assert(cu<std::uint16_t>(1u).get<std::uint64_t>() == 1, "crag::core::closed_unit test failed");
-static_assert(cu<std::uint16_t>(2).get<float>() != 2, "crag::core::closed_unit test failed");	// out-of-range test
+static_assert(cu<std::uint8_t>(.5).get<double>() == .5, "sg14::closed_unit test failed");
+static_assert(cu<std::uint16_t>(.125f).get<float>() == .125f, "sg14::closed_unit test failed");
+static_assert(cu<std::uint16_t>(.640625l).get<float>() == .640625, "sg14::closed_unit test failed");
+static_assert(cu<std::uint16_t>(1.640625).get<float>() == 1.640625f, "sg14::closed_unit test failed");
+static_assert(cu<std::uint16_t>(1u).get<std::uint64_t>() == 1, "sg14::closed_unit test failed");
+static_assert(cu<std::uint16_t>(2).get<float>() != 2, "sg14::closed_unit test failed");	// out-of-range test
 
 // open_unit
 template <typename T> using ou = open_unit<T>;
-static_assert(ou<std::uint8_t>(.5).get<double>() == .5, "crag::core::closed_unit test failed");
-static_assert(ou<std::uint16_t>(.125f).get<float>() == .125f, "crag::core::closed_unit test failed");
-static_assert(ou<std::uint16_t>(.640625l).get<float>() == .640625, "crag::core::closed_unit test failed");
-static_assert(ou<std::uint16_t>(1).get<float>() == 0, "crag::core::closed_unit test failed");	// dropped bit
+static_assert(ou<std::uint8_t>(.5).get<double>() == .5, "sg14::closed_unit test failed");
+static_assert(ou<std::uint16_t>(.125f).get<float>() == .125f, "sg14::closed_unit test failed");
+static_assert(ou<std::uint16_t>(.640625l).get<float>() == .640625, "sg14::closed_unit test failed");
+static_assert(ou<std::uint16_t>(1).get<float>() == 0, "sg14::closed_unit test failed");	// dropped bit
 
 ////////////////////////////////////////////////////////////////////////////////
-// crag::core::lerp
+// arithmetic
 
-static_assert(lerp(fp_u8<-7>(1), fp_u8<-7>(0), .5).get<float>() == .5f, "crag::core::lerp test failed");
-static_assert(lerp(fp_u16<-7>(.125), fp_u16<-7>(.625), .5).get<float>() == .375f, "crag::core::lerp test failed");
-static_assert(lerp(fp_u32<-16>(42123.51323), fp_u32<-16>(432.9191), .812).get<unsigned>() == 8270, "crag::core::lerp test failed");
+// addition
+static_assert((fp_s32<0>(123) + fp_s32<0>(123)).get<int>() == 246, "sg14::fixed_point test failed");
+static_assert((fp_s32<-16>(123.125) + fp_s32<-16>(123.75)).get<float>() == 246.875, "sg14::fixed_point test failed");
 
-static_assert(lerp(fp_s8<-6>(1), fp_s8<-6>(0), .5).get<float>() == .5f, "crag::core::lerp test failed");
-static_assert(lerp(fp_s16<-10>(.125), fp_s16<-10>(.625), .5).get<float>() == .375f, "crag::core::lerp test failed");
-static_assert(lerp(fp_s32<-6>(.125), fp_s32<-6>(.625), .25).get<float>() == .25f, "crag::core::lerp test failed");
+// subtraction
+static_assert((fp_s32<0>(999) - fp_s32<0>(369)).get<int>() == 630, "sg14::fixed_point test failed");
+static_assert((fp_s32<-16>(246.875) - fp_s32<-16>(123.75)).get<float>() == 123.125, "sg14::fixed_point test failed");
+static_assert((fp_s16<-4>(123.125) - fp_s16<-4>(246.875)).get<float>() == -123.75, "sg14::fixed_point test failed");
+
+// multiplication
+static_assert((fp_u8<0>(0x55) * fp_u8<0>(2)).get<int>() == 0xaa, "sg14::fixed_point test failed");
+static_assert((fp_u64<-8>(1003006) * fp_u64<-8>(7)).get<int>() == 7021042, "sg14::fixed_point test failed");
+static_assert((fp_s32<-16>(123.75) * fp_s32<-16>(44.5)).get<float>() == 5506.875, "sg14::fixed_point test failed");
+
+// division
+static_assert((fp_s8<-1>(63) / fp_s8<-1>(-4)).get<float>() == -15.5, "sg14::fixed_point test failed");
+static_assert((fp_s8<1>(-255) / fp_s8<1>(-8)).get<int>() == 32, "sg14::fixed_point test failed");
+static_assert((fp_s32<0>(-999) / fp_s32<0>(3)).get<int>() == -333, "sg14::fixed_point test failed");
+static_assert((fp_u64<-8>(65535) / fp_u64<-8>(256)).get<int>() == 255, "sg14::fixed_point test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// sg14::abs
+
+static_assert(sg14::abs(fp_s8<0>(66)).get<int>() == 66, "sg14::sqrt test failed");
+static_assert(sg14::abs(fp_s8<0>(-123)).get<int>() == 123, "sg14::sqrt test failed");
+static_assert(sg14::abs(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
+static_assert(sg14::abs(fp_s64<0>(-9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// sg14::sqrt
+
+static_assert(sg14::sqrt(fp_u8<0>(225)).get<int>() == 15, "sg14::sqrt test failed");
+//static_assert(sg14::sqrt(fp_s32<-24>(3.141592654)).get<float>() == 1.772453851, "sg14::sqrt test failed");
+static_assert(sg14::sqrt(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 3037000499, "sg14::sqrt test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// sg14::lerp
+
+static_assert(sg14::lerp(fp_u8<-7>(1), fp_u8<-7>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
+static_assert(sg14::lerp(fp_u16<-7>(.125), fp_u16<-7>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
+static_assert(sg14::lerp(fp_u32<-16>(42123.51323), fp_u32<-16>(432.9191), .812).get<unsigned>() == 8270, "sg14::lerp test failed");
+
+static_assert(sg14::lerp(fp_s8<-6>(1), fp_s8<-6>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
+static_assert(sg14::lerp(fp_s16<-10>(.125), fp_s16<-10>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
+static_assert(sg14::lerp(fp_s32<-6>(.125), fp_s32<-6>(.625), .25).get<float>() == .25f, "sg14::lerp test failed");

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -127,6 +127,11 @@ static_assert(fp_s8<1>(255).get<int>() == 254, "sg14::fixed_point test failed");
 static_assert(fp_s8<1>(254).get<int>() == 254, "sg14::fixed_point test failed");
 static_assert(fp_s8<1>(-5).get<int>() == -6, "sg14::fixed_point test failed");
 
+// conversion between fixed_point specializations
+static_assert(fp_u8<-4>(fp_s16<-8>(1.5)).get<float>() == 1.5, "sg14::fixed_point test failed");
+static_assert(fp_u16<-8>(fp_s8<-4>(3.25)).get<float>() == 3.25, "sg14::fixed_point test failed");
+static_assert(fp_u8<4>(fp_s16<-4>(768)).get<int>() == 768, "sg14::fixed_point test failed");
+
 // closed_unit
 template <typename T> using cu = closed_unit<T>;
 static_assert(cu<std::uint8_t>(.5).get<double>() == .5, "sg14::closed_unit test failed");

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -7,6 +7,11 @@ using namespace sg14;
 // sg14::_impl
 
 ////////////////////////////////////////////////////////////////////////////////
+// sg14::_impl::is_integral
+
+static_assert(_impl::is_integral<int>(), "sg14::_impl::is_integral test failed");
+
+////////////////////////////////////////////////////////////////////////////////
 // sg14::_impl::shift_left/right positive RHS
 
 static_assert(_impl::shift_left<8, std::uint16_t>((std::uint16_t)0x1234) == 0x3400, "sg14::_impl::shift_left test failed");
@@ -14,9 +19,9 @@ static_assert(_impl::shift_left<8, std::uint16_t>((std::uint8_t)0x1234) == 0x340
 static_assert(_impl::shift_left<8, std::uint8_t>((std::uint16_t)0x1234) == 0x0, "sg14::_impl::shift_left test failed");
 static_assert(_impl::shift_left<8, std::int16_t>(-123) == -31488, "sg14::_impl::shift_left test failed");
 
-static_assert(_impl::shift_right<8, std::uint16_t, std::uint16_t>(0x1234) == 0x12, "sg14::_impl::shift_right test failed");
-static_assert(_impl::shift_right<8, std::uint16_t, std::uint8_t>(0x1234) == 0x0, "sg14::_impl::shift_right test failed");
-static_assert(_impl::shift_right<8, std::uint8_t, std::uint16_t>(0x1234) == 0x12, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, std::uint16_t>((std::uint16_t)0x1234) == 0x12, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, std::uint16_t>((std::uint8_t)0x1234) == 0x0, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_right<8, std::uint8_t>((std::uint16_t)0x1234) == 0x12, "sg14::_impl::shift_right test failed");
 static_assert(_impl::shift_right<8, std::int16_t>(-31488) == -123, "sg14::_impl::shift_right test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -63,37 +68,37 @@ template <int E> using fp_s64 = fixed_point<std::int64_t, E>;
 // conversion
 
 // exponent == 0
-static_assert(fp_u8<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
-static_assert(fp_u16<0>(12.34f).get<double>() == 12.f, "sg14::fixed_point test failed");
-static_assert(fp_u32<0>(12.34f).get<long double>() == 12.f, "sg14::fixed_point test failed");
-static_assert(fp_u64<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
-
-static_assert(fp_s8<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
-static_assert(fp_s16<0>(-12.34f).get<long double>() == -12.f, "sg14::fixed_point test failed");
-static_assert(fp_s32<0>(-12.34f).get<float>() == -12.f, "sg14::fixed_point test failed");
-static_assert(fp_s64<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
-
-// exponent = -1
-static_assert(fp_u8<-1>(127.5).get<float>() == 127.5, "sg14::fixed_point test failed");
-
-static_assert(fp_s8<-1>(63.5).get<float>() == 63.5, "sg14::fixed_point test failed");
-static_assert(fp_s8<-1>(-63.5).get<float>() == -63.5, "sg14::fixed_point test failed");
-
-// exponent == -7
-static_assert(fp_u8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
-static_assert(fp_u16<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fp_u32<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fp_u64<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
-
-static_assert(fp_s8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
-static_assert(fp_s16<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
-static_assert(fp_s32<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
-static_assert(fp_s64<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
-
-static_assert(fp_u8<-7>(.125f).get<double>() == .125f, "sg14::fixed_point test failed");
-static_assert(fp_u16<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fp_u32<-7>(232.125f).get<double>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fp_u64<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
+//static_assert(fp_u8<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
+//static_assert(fp_u16<0>(12.34f).get<double>() == 12.f, "sg14::fixed_point test failed");
+//static_assert(fp_u32<0>(12.34f).get<long double>() == 12.f, "sg14::fixed_point test failed");
+//static_assert(fp_u64<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
+//
+//static_assert(fp_s8<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
+//static_assert(fp_s16<0>(-12.34f).get<long double>() == -12.f, "sg14::fixed_point test failed");
+//static_assert(fp_s32<0>(-12.34f).get<float>() == -12.f, "sg14::fixed_point test failed");
+//static_assert(fp_s64<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
+//
+//// exponent = -1
+//static_assert(fp_u8<-1>(127.5).get<float>() == 127.5, "sg14::fixed_point test failed");
+//
+//static_assert(fp_s8<-1>(63.5).get<float>() == 63.5, "sg14::fixed_point test failed");
+//static_assert(fp_s8<-1>(-63.5).get<float>() == -63.5, "sg14::fixed_point test failed");
+//
+//// exponent == -7
+//static_assert(fp_u8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
+//static_assert(fp_u16<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+//static_assert(fp_u32<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+//static_assert(fp_u64<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+//
+//static_assert(fp_s8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
+//static_assert(fp_s16<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+//static_assert(fp_s32<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+//static_assert(fp_s64<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+//
+//static_assert(fp_u8<-7>(.125f).get<double>() == .125f, "sg14::fixed_point test failed");
+//static_assert(fp_u16<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
+//static_assert(fp_u32<-7>(232.125f).get<double>() == 232.125f, "sg14::fixed_point test failed");
+//static_assert(fp_u64<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
 
 static_assert(fp_s8<-7>(1).get<long double>() != 1.f, "sg14::fixed_point test failed");
 static_assert(fp_s8<-7>(.5).get<float>() == .5f, "sg14::fixed_point test failed");
@@ -152,14 +157,18 @@ static_assert((fp_s16<-4>(123.125) - fp_s16<-4>(246.875)).get<float>() == -123.7
 
 // multiplication
 static_assert((fp_u8<0>(0x55) * fp_u8<0>(2)).get<int>() == 0xaa, "sg14::fixed_point test failed");
-static_assert((fp_u64<-8>(1003006) * fp_u64<-8>(7)).get<int>() == 7021042, "sg14::fixed_point test failed");
 static_assert((fp_s32<-16>(123.75) * fp_s32<-16>(44.5)).get<float>() == 5506.875, "sg14::fixed_point test failed");
+#if defined(_SG14_FIXED_POINT_64)
+static_assert((fp_u64<-8>(1003006) * fp_u64<-8>(7)).get<int>() == 7021042, "sg14::fixed_point test failed");
+#endif
 
 // division
 static_assert((fp_s8<-1>(63) / fp_s8<-1>(-4)).get<float>() == -15.5, "sg14::fixed_point test failed");
 static_assert((fp_s8<1>(-255) / fp_s8<1>(-8)).get<int>() == 32, "sg14::fixed_point test failed");
 static_assert((fp_s32<0>(-999) / fp_s32<0>(3)).get<int>() == -333, "sg14::fixed_point test failed");
+#if defined(_SG14_FIXED_POINT_64)
 static_assert((fp_u64<-8>(65535) / fp_u64<-8>(256)).get<int>() == 255, "sg14::fixed_point test failed");
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::abs
@@ -174,7 +183,9 @@ static_assert(sg14::abs(fp_s64<0>(-9223372036854775807)).get<std::int64_t>() == 
 
 static_assert(sg14::sqrt(fp_u8<0>(225)).get<int>() == 15, "sg14::sqrt test failed");
 //static_assert(sg14::sqrt(fp_s32<-24>(3.141592654)).get<float>() == 1.772453851, "sg14::sqrt test failed");
+#if defined(_SG14_FIXED_POINT_64)
 static_assert(sg14::sqrt(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 3037000499, "sg14::sqrt test failed");
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::lerp

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -189,7 +189,14 @@ static_assert(sg14::abs(fp_s64<0>(-9223372036854775807)).get<std::int64_t>() == 
 // sg14::sqrt
 
 static_assert(sg14::sqrt(fp_u8<0>(225)).get<int>() == 15, "sg14::sqrt test failed");
-//static_assert(sg14::sqrt(fp_s32<-24>(3.141592654)).get<float>() == 1.772453851, "sg14::sqrt test failed");
+static_assert(sg14::sqrt(fp_s8<0>(81)).get<int>() == 9, "sg14::sqrt test failed");
+
+static_assert(sg14::sqrt(fp_u8<-1>(4)).get<int>() == 2, "sg14::sqrt test failed");
+static_assert(sg14::sqrt(fp_s8<-2>(9)).get<int>() == 3, "sg14::sqrt test failed");
+
+static_assert(sg14::sqrt(fp_u8<-4>(4)).get<int>() == 2, "sg14::sqrt test failed");
+static_assert(sg14::sqrt(fp_s32<-24>(3.141592654)).get<float>() > 1.7724537849426, "sg14::sqrt test failed");
+static_assert(sg14::sqrt(fp_s32<-24>(3.141592654)).get<float>() < 1.7724537849427, "sg14::sqrt test failed");
 #if defined(_SG14_FIXED_POINT_64)
 static_assert(sg14::sqrt(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 3037000499, "sg14::sqrt test failed");
 #endif

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -68,37 +68,37 @@ template <int E> using fp_s64 = fixed_point<std::int64_t, E>;
 // conversion
 
 // exponent == 0
-//static_assert(fp_u8<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
-//static_assert(fp_u16<0>(12.34f).get<double>() == 12.f, "sg14::fixed_point test failed");
-//static_assert(fp_u32<0>(12.34f).get<long double>() == 12.f, "sg14::fixed_point test failed");
-//static_assert(fp_u64<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
-//
-//static_assert(fp_s8<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
-//static_assert(fp_s16<0>(-12.34f).get<long double>() == -12.f, "sg14::fixed_point test failed");
-//static_assert(fp_s32<0>(-12.34f).get<float>() == -12.f, "sg14::fixed_point test failed");
-//static_assert(fp_s64<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
-//
-//// exponent = -1
-//static_assert(fp_u8<-1>(127.5).get<float>() == 127.5, "sg14::fixed_point test failed");
-//
-//static_assert(fp_s8<-1>(63.5).get<float>() == 63.5, "sg14::fixed_point test failed");
-//static_assert(fp_s8<-1>(-63.5).get<float>() == -63.5, "sg14::fixed_point test failed");
-//
-//// exponent == -7
-//static_assert(fp_u8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
-//static_assert(fp_u16<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
-//static_assert(fp_u32<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
-//static_assert(fp_u64<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
-//
-//static_assert(fp_s8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
-//static_assert(fp_s16<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
-//static_assert(fp_s32<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
-//static_assert(fp_s64<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
-//
-//static_assert(fp_u8<-7>(.125f).get<double>() == .125f, "sg14::fixed_point test failed");
-//static_assert(fp_u16<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
-//static_assert(fp_u32<-7>(232.125f).get<double>() == 232.125f, "sg14::fixed_point test failed");
-//static_assert(fp_u64<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fp_u8<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
+static_assert(fp_u16<0>(12.34f).get<double>() == 12.f, "sg14::fixed_point test failed");
+static_assert(fp_u32<0>(12.34f).get<long double>() == 12.f, "sg14::fixed_point test failed");
+static_assert(fp_u64<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
+
+static_assert(fp_s8<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
+static_assert(fp_s16<0>(-12.34f).get<long double>() == -12.f, "sg14::fixed_point test failed");
+static_assert(fp_s32<0>(-12.34f).get<float>() == -12.f, "sg14::fixed_point test failed");
+static_assert(fp_s64<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
+
+// exponent = -1
+static_assert(fp_u8<-1>(127.5).get<float>() == 127.5, "sg14::fixed_point test failed");
+
+static_assert(fp_s8<-1>(63.5).get<float>() == 63.5, "sg14::fixed_point test failed");
+static_assert(fp_s8<-1>(-63.5).get<float>() == -63.5, "sg14::fixed_point test failed");
+
+// exponent == -7
+static_assert(fp_u8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
+static_assert(fp_u16<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fp_u32<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fp_u64<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+
+static_assert(fp_s8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
+static_assert(fp_s16<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(fp_s32<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(fp_s64<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+
+static_assert(fp_u8<-7>(.125f).get<double>() == .125f, "sg14::fixed_point test failed");
+static_assert(fp_u16<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fp_u32<-7>(232.125f).get<double>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fp_u64<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
 
 static_assert(fp_s8<-7>(1).get<long double>() != 1.f, "sg14::fixed_point test failed");
 static_assert(fp_s8<-7>(.5).get<float>() == .5f, "sg14::fixed_point test failed");

--- a/VS2015/.gitignore
+++ b/VS2015/.gitignore
@@ -1,0 +1,6 @@
+# Visual Studio 2015 files
+.suo
+Debug
+Release
+SG14.opensdf
+SG14.sdf


### PR DESCRIPTION
* Support for 64-bit types on Clang and GCC;
* conversion between different specializations;
* some basic arithmetic overloads;
* sg14::abs;
* sg14::sqrt - optimized for compile-time calculation; probably requires faster implementation using look-up tables;
* placeholder streaming operators and
* some fixes and new tests along the way.