### PR TITLE
Promotion

### DIFF
--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -348,14 +348,14 @@ namespace sg14
 		// c'tor taking an integer type
 		template <typename S, typename std::enable_if<_impl::is_integral<S>::value, int>::type dummy = 0>
 		constexpr fixed_point(S s) noexcept
-			: _repr(int_to_repr(s))
+			: _repr(integral_to_repr(s))
 		{
 		}
 
 		// c'tor taking a floating-point type
 		template <typename S, typename std::enable_if<std::is_floating_point<S>::value, int>::type dummy = 0>
 		constexpr fixed_point(S s) noexcept
-			: _repr(float_to_repr(s))
+			: _repr(floating_point_to_repr(s))
 		{
 		}
 
@@ -370,14 +370,14 @@ namespace sg14
 		template <typename S, typename std::enable_if<_impl::is_integral<S>::value, int>::type dummy = 0>
 		constexpr S get() const noexcept
 		{
-			return repr_to_int<S>(_repr);
+			return repr_to_integral<S>(_repr);
 		}
 
 		// returns value represented as integral
 		template <typename S, typename std::enable_if<std::is_floating_point<S>::value, int>::type dummy = 0>
 		constexpr S get() const noexcept
 		{
-			return repr_to_float<S>(_repr);
+			return repr_to_floating_point<S>(_repr);
 		}
 
 		// returns internal representation of value
@@ -473,7 +473,7 @@ namespace sg14
 		template <typename S, typename std::enable_if<_impl::is_integral<S>::value, int>::type dummy = 0>
 		static constexpr S one() noexcept
 		{
-			return int_to_repr<S>(1);
+			return integral_to_repr<S>(1);
 		}
 
 		template <typename S>
@@ -484,7 +484,7 @@ namespace sg14
 		}
 
 		template <typename S>
-		static constexpr repr_type int_to_repr(S s) noexcept
+		static constexpr repr_type integral_to_repr(S s) noexcept
 		{
 			static_assert(_impl::is_integral<S>::value, "S must be unsigned integral type");
 
@@ -492,7 +492,7 @@ namespace sg14
 		}
 
 		template <typename S>
-		static constexpr S repr_to_int(repr_type r) noexcept
+		static constexpr S repr_to_integral(repr_type r) noexcept
 		{
 			static_assert(_impl::is_integral<S>::value, "S must be unsigned integral type");
 
@@ -500,14 +500,14 @@ namespace sg14
 		}
 
 		template <typename S>
-		static constexpr repr_type float_to_repr(S s) noexcept
+		static constexpr repr_type floating_point_to_repr(S s) noexcept
 		{
 			static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
 			return static_cast<repr_type>(s * one<S>());
 		}
 
 		template <typename S>
-		static constexpr S repr_to_float(repr_type r) noexcept
+		static constexpr S repr_to_floating_point(repr_type r) noexcept
 		{
 			static_assert(std::is_floating_point<S>::value, "S must be floating-point type");
 			return S(r) * inverse_one<S>();

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -564,6 +564,26 @@ namespace sg14
 		INTEGER_BITS + std::is_signed<REPR_TYPE>::value - sizeof(REPR_TYPE) * CHAR_BIT>;
 
 	////////////////////////////////////////////////////////////////////////////////
+	// sg14::fixed_point_mul_result_t
+
+	// yields specialization of fixed_point with integral bits necessary to store 
+	// result of a multiply between values of fixed_point<REPR_TYPE, EXPONENT>
+	template <typename REPR_TYPE, int EXPONENT>
+	using fixed_point_mul_result_t = fixed_point_by_integer_digits_t<
+		REPR_TYPE,
+		fixed_point<REPR_TYPE, EXPONENT>::integer_digits * 2>;
+
+	////////////////////////////////////////////////////////////////////////////////
+	// sg14::fixed_point_add_result_t
+
+	// yields specialization of fixed_point with integral bits necessary to store 
+	// result of an addition between N values of fixed_point<REPR_TYPE, EXPONENT>
+	template <typename REPR_TYPE, int EXPONENT, unsigned N = 2>
+	using fixed_point_add_result_t = fixed_point_by_integer_digits_t<
+		REPR_TYPE,
+		fixed_point<REPR_TYPE, EXPONENT>::integer_digits + _impl::capacity<N - 1>::value>;
+
+	////////////////////////////////////////////////////////////////////////////////
 	// sg14::lerp
 
 	// linear interpolation between two fixed_point values

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -693,6 +693,66 @@ namespace sg14
 		fp = ld;
 		return in;
 	}
+
+	////////////////////////////////////////////////////////////////////////////////
+	// fixed_point specializations
+
+	using fixed0_7_t = fixed_point<std::int8_t, -7>;
+	using fixed1_6_t = fixed_point<std::int8_t, -6>;
+	using fixed3_4_t = fixed_point<std::int8_t, -4>;
+	using fixed4_3_t = fixed_point<std::int8_t, -3>;
+	using fixed7_0_t = fixed_point<std::int8_t, 0>;
+
+	using ufixed0_8_t = fixed_point<std::uint8_t, -8>;
+	using ufixed1_7_t = fixed_point<std::uint8_t, -7>;
+	using ufixed4_4_t = fixed_point<std::uint8_t, -4>;
+	using ufixed8_0_t = fixed_point<std::uint8_t, 0>;
+
+	using fixed0_15_t = fixed_point<std::int16_t, -15>;
+	using fixed1_14_t = fixed_point<std::int16_t, -14>;
+	using fixed7_8_t = fixed_point<std::int16_t, -8>;
+	using fixed8_7_t = fixed_point<std::int16_t, -7>;
+	using fixed15_0_t = fixed_point<std::int16_t, 0>;
+
+	using ufixed0_16_t = fixed_point<std::uint16_t, -16>;
+	using ufixed1_15_t = fixed_point<std::uint16_t, -15>;
+	using ufixed8_8_t = fixed_point<std::uint16_t, -8>;
+	using ufixed16_0_t = fixed_point<std::uint16_t, 0>;
+
+	using fixed0_31_t = fixed_point<std::int32_t, -31>;
+	using fixed1_30_t = fixed_point<std::int32_t, -30>;
+	using fixed15_16_t = fixed_point<std::int32_t, -16>;
+	using fixed16_15_t = fixed_point<std::int32_t, -15>;
+	using fixed31_0_t = fixed_point<std::int32_t, 0>;
+
+	using ufixed0_32_t = fixed_point<std::uint32_t, -32>;
+	using ufixed1_31_t = fixed_point<std::uint32_t, -31>;
+	using ufixed16_16_t = fixed_point<std::uint32_t, -16>;
+	using ufixed32_0_t = fixed_point<std::uint32_t, 0>;
+
+	using fixed0_63_t = fixed_point<std::int64_t, -63>;
+	using fixed1_62_t = fixed_point<std::int64_t, -62>;
+	using fixed31_32_t = fixed_point<std::int64_t, -32>;
+	using fixed32_31_t = fixed_point<std::int64_t, -31>;
+	using fixed63_0_t = fixed_point<std::int64_t, 0>;
+
+	using ufixed0_64_t = fixed_point<std::uint64_t, -64>;
+	using ufixed1_63_t = fixed_point<std::uint64_t, -63>;
+	using ufixed32_32_t = fixed_point<std::uint64_t, -32>;
+	using ufixed64_0_t = fixed_point<std::uint64_t, 0>;
+
+#if defined(_SG14_FIXED_POINT_128)
+	using fixed0_127_t = fixed_point<__int128_t, -127>;
+	using fixed1_126_t = fixed_point<__int128_t, -126>;
+	using fixed63_64_t = fixed_point<__int128_t, -64>;
+	using fixed64_63_t = fixed_point<__int128_t, -64>;
+	using fixed127_0_t = fixed_point<__int128_t, 0>;
+
+	using ufixed0_128_t = fixed_point<unsigned __int128_t, -128>;
+	using ufixed1_127_t = fixed_point<unsigned __int128_t, -127>;
+	using ufixed64_64_t = fixed_point<unsigned __int128_t, -64>;
+	using ufixed128_0_t = fixed_point<unsigned __int128_t, 0>;
+#endif
 }
 
 #endif	// defined(_SG14_FIXED_POINT)

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -12,7 +12,7 @@
 #if defined(__clang__) || defined(__GNUG__)
 // sg14::float_point only fully supports 64-bit types with the help of 128-bit ints.
 // Clang and GCC use (__int128) and (unsigned __int128) for 128-bit ints.
-#define _SG14_FIXED_POINT_64
+#define _SG14_FIXED_POINT_128
 #endif
 
 namespace sg14
@@ -40,7 +40,7 @@ namespace sg14
 		template <> struct next_size<std::uint32_t> { using type = std::uint64_t; };
 		template <> struct next_size<std::int32_t> { using type = std::int64_t; };
 
-#if defined(_SG14_FIXED_POINT_64)
+#if defined(_SG14_FIXED_POINT_128)
 		template <> struct next_size<std::uint64_t> { using type = unsigned __int128; };
 		template <> struct next_size<std::int64_t> { using type = __int128; };
 #endif
@@ -55,7 +55,7 @@ namespace sg14
 		template <>
 		struct is_integral<bool> : std::false_type { };
 
-#if defined(_SG14_FIXED_POINT_64)
+#if defined(_SG14_FIXED_POINT_128)
 		// addresses https://llvm.org/bugs/show_bug.cgi?id=23156
 		template <>
 		struct is_integral<__int128> : std::true_type { };

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -554,6 +554,16 @@ namespace sg14
 	using fixed_point_demotion_t = fixed_point<_impl::previous_size_t<REPR_TYPE>, EXPONENT / 2>;
 
 	////////////////////////////////////////////////////////////////////////////////
+	// sg14::fixed_point_by_integer_digits_t
+
+	// yields a float_point with EXPONENT calculated such that 
+	// fixed_point<REPR_TYPE, EXPONENT>::integer_bits == INTEGER_BITS
+	template <typename REPR_TYPE, int INTEGER_BITS>
+	using fixed_point_by_integer_digits_t = fixed_point<
+		REPR_TYPE, 
+		INTEGER_BITS + std::is_signed<REPR_TYPE>::value - sizeof(REPR_TYPE) * CHAR_BIT>;
+
+	////////////////////////////////////////////////////////////////////////////////
 	// sg14::lerp
 
 	// linear interpolation between two fixed_point values

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -155,9 +155,9 @@ namespace sg14
 			typename OUTPUT,
 			typename INPUT,
 			typename std::enable_if<
-			EXPONENT >= 0 && sizeof(OUTPUT) <= sizeof(INPUT) && std::is_signed<INPUT>::value,
-			int>::type dummy = 0>
-			constexpr OUTPUT shift_left(INPUT i) noexcept
+				EXPONENT >= 0 && sizeof(OUTPUT) <= sizeof(INPUT) && std::is_signed<INPUT>::value,
+				int>::type dummy = 0>
+		constexpr OUTPUT shift_left(INPUT i) noexcept
 		{
 			static_assert(_impl::is_integral<INPUT>::value, "INPUT must be integral type");
 			static_assert(_impl::is_integral<OUTPUT>::value, "OUTPUT must be integral type");

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -311,7 +311,7 @@ namespace sg14
 		constexpr static int exponent = EXPONENT;
 		constexpr static int digits = std::numeric_limits<repr_type>::digits;
 		constexpr static int integer_digits = digits + exponent;
-		constexpr static int fractional_digits = digits + exponent;
+		constexpr static int fractional_digits = digits - integer_digits;
 
 		////////////////////////////////////////////////////////////////////////////////
 		// functions

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -260,6 +260,25 @@ namespace sg14
 		}
 
 		////////////////////////////////////////////////////////////////////////////////
+		// sg14::_impl::capacity
+
+		// has value that, given a value N, 
+		// returns number of bits necessary to represent it in binary
+		template <unsigned N> struct capacity;
+
+		template <>
+		struct capacity<0>
+		{
+			static constexpr int value = 0;
+		};
+
+		template <unsigned N>
+		struct capacity
+		{
+			static constexpr int value = capacity<N / 2>::value + 1;
+		};
+
+		////////////////////////////////////////////////////////////////////////////////
 		// sg14::sqrt helper functions
 
 		template <typename REPR_TYPE>

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -317,7 +317,7 @@ namespace sg14
 		// functions
 
 	private:
-		// constructor taking represenation explicitly using operator++(int)-style trick
+		// constructor taking representation explicitly using operator++(int)-style trick
 		constexpr fixed_point(repr_type repr, int) noexcept
 			: _repr(repr)
 		{

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -673,7 +673,7 @@ namespace sg14
 	constexpr fixed_point<REPR_TYPE, EXPONENT> sqrt(fixed_point<REPR_TYPE, EXPONENT> const & x) noexcept
 	{
 		return fixed_point<REPR_TYPE, EXPONENT>::from_data(
-			static_cast<REPR_TYPE>(_impl::sqrt_solve1(fixed_point_promotion_t<REPR_TYPE, EXPONENT>(x).data())));
+			static_cast<REPR_TYPE>(_impl::sqrt_solve1(promote(x).data())));
 	}
 
 	////////////////////////////////////////////////////////////////////////////////

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -536,7 +536,7 @@ namespace sg14
 		1 - static_cast<int>(sizeof(REPR_TYPE)) * CHAR_BIT>;
 
 	////////////////////////////////////////////////////////////////////////////////
-	// sg14::fixed_point_promotion_t
+	// sg14::fixed_point_promotion_t / promote
 
 	// given template parameters of a fixed_point specialization, 
 	// yields alternative specialization with twice the fractional bits
@@ -544,14 +544,30 @@ namespace sg14
 	template <typename REPR_TYPE, int EXPONENT>
 	using fixed_point_promotion_t = fixed_point<_impl::next_size_t<REPR_TYPE>, EXPONENT * 2>;
 
+	// as fixed_point_promotion_t but promotes parameter, from
+	template <typename REPR_TYPE, int EXPONENT>
+	fixed_point_promotion_t<REPR_TYPE, EXPONENT>
+	constexpr promote(fixed_point<REPR_TYPE, EXPONENT> const & from) noexcept
+	{
+		return from;
+	}
+
 	////////////////////////////////////////////////////////////////////////////////
-	// sg14::fixed_point_demotion_t
+	// sg14::fixed_point_demotion_t / demote
 
 	// given template parameters of a fixed_point specialization, 
 	// yields alternative specialization with half the fractional bits
 	// and half the integral/sign bits (assuming EXPONENT is even)
 	template <typename REPR_TYPE, int EXPONENT>
 	using fixed_point_demotion_t = fixed_point<_impl::previous_size_t<REPR_TYPE>, EXPONENT / 2>;
+
+	// as fixed_point_demotion_t but demotes parameter, from
+	template <typename REPR_TYPE, int EXPONENT>
+	fixed_point_demotion_t<REPR_TYPE, EXPONENT>
+	constexpr demote(fixed_point<REPR_TYPE, EXPONENT> const & from) noexcept
+	{
+		return from;
+	}
 
 	////////////////////////////////////////////////////////////////////////////////
 	// sg14::fixed_point_by_integer_digits_t

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -191,13 +191,13 @@ static_assert((fp_u64<-8>(65535) / fp_u64<-8>(256)).get<int>() == 255, "sg14::fi
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-// sg14::promotion
+// sg14::fixed_point_promotion_t
 
 static_assert(std::is_same<sg14::fixed_point_promotion_t<std::int8_t, -4>, sg14::fixed_point<std::int16_t, -8>>::value, "sg14::promotion test failed");
 static_assert(std::is_same<sg14::fixed_point_promotion_t<std::uint32_t, 44>, sg14::fixed_point<std::uint64_t, 88>>::value, "sg14::promotion test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
-// sg14::demotion
+// sg14::fixed_point_demotion_t
 
 static_assert(std::is_same<sg14::fixed_point<std::int8_t, -4>, sg14::fixed_point_demotion_t<std::int16_t, -8>>::value, "sg14::promotion test failed");
 static_assert(std::is_same<sg14::fixed_point<std::uint32_t, 44>, sg14::fixed_point_demotion_t<std::uint64_t, 88>>::value, "sg14::promotion test failed");

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -203,6 +203,12 @@ static_assert(std::is_same<sg14::fixed_point<std::int8_t, -4>, sg14::fixed_point
 static_assert(std::is_same<sg14::fixed_point<std::uint32_t, 44>, sg14::fixed_point_demotion_t<std::uint64_t, 88>>::value, "sg14::promotion test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
+// sg14::fixed_point_by_integer_digits_t
+
+static_assert(sg14::fixed_point_by_integer_digits_t<std::uint8_t, 8>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(sg14::fixed_point_by_integer_digits_t<std::int32_t, 27>::integer_digits == 27, "sg14::fixed_point_by_integer_digits_t test failed");
+
+////////////////////////////////////////////////////////////////////////////////
 // sg14::abs
 
 static_assert(sg14::abs(fp_s8<0>(66)).get<int>() == 66, "sg14::sqrt test failed");

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -218,6 +218,18 @@ static_assert(sg14::fixed_point_by_integer_digits_t<std::uint8_t, 8>::integer_di
 static_assert(sg14::fixed_point_by_integer_digits_t<std::int32_t, 27>::integer_digits == 27, "sg14::fixed_point_by_integer_digits_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
+// sg14::fixed_point_mul_result_t
+
+static_assert(sg14::fixed_point_mul_result_t<std::uint8_t, -4>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(sg14::fixed_point_mul_result_t<std::int32_t, -25>::integer_digits == 12, "sg14::fixed_point_by_integer_digits_t test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// sg14::fixed_point_add_result_t
+
+static_assert(sg14::fixed_point_add_result_t<std::uint8_t, -4>::integer_digits == 5, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(sg14::fixed_point_add_result_t<std::int32_t, -25, 4>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
+
+////////////////////////////////////////////////////////////////////////////////
 // sg14::abs
 
 static_assert(sg14::abs(fp_s8<0>(66)).get<int>() == 66, "sg14::sqrt test failed");

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -65,138 +65,115 @@ static_assert(_impl::capacity<16>::value == 5, "sg14::_impl::capacity test faile
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point
 
-template <typename T, int E> using fp = fixed_point<T, E>;
-
-template <int E> using fp_u8 = fixed_point<std::uint8_t, E>;
-template <int E> using fp_u16 = fixed_point<std::uint16_t, E>;
-template <int E> using fp_u32 = fixed_point<std::uint32_t, E>;
-template <int E> using fp_u64 = fixed_point<std::uint64_t, E>;
-
-template <int E> using fp_s8 = fixed_point<std::int8_t, E>;
-template <int E> using fp_s16 = fixed_point<std::int16_t, E>;
-template <int E> using fp_s32 = fixed_point<std::int32_t, E>;
-template <int E> using fp_s64 = fixed_point<std::int64_t, E>;
-
 ////////////////////////////////////////////////////////////////////////////////
 // conversion
 
 // exponent == 0
-static_assert(fp_u8<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
-static_assert(fp_u16<0>(12.34f).get<double>() == 12.f, "sg14::fixed_point test failed");
-static_assert(fp_u32<0>(12.34f).get<long double>() == 12.f, "sg14::fixed_point test failed");
-static_assert(fp_u64<0>(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
+static_assert(ufixed8_0_t(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
+static_assert(ufixed16_0_t(12.34f).get<double>() == 12.f, "sg14::fixed_point test failed");
+static_assert(ufixed32_0_t(12.34f).get<long double>() == 12.f, "sg14::fixed_point test failed");
+static_assert(ufixed64_0_t(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
 
-static_assert(fp_s8<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
-static_assert(fp_s16<0>(-12.34f).get<long double>() == -12.f, "sg14::fixed_point test failed");
-static_assert(fp_s32<0>(-12.34f).get<float>() == -12.f, "sg14::fixed_point test failed");
-static_assert(fp_s64<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
-
-static_assert(fp_s8<0>::integer_digits == 7, "sg14::fixed_point test failed");
-static_assert(fp_u64<0>::fractional_digits == 0, "sg14::fixed_point test failed");
+static_assert(fixed7_0_t(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
+static_assert(fixed15_0_t(-12.34f).get<long double>() == -12.f, "sg14::fixed_point test failed");
+static_assert(fixed31_0_t(-12.34f).get<float>() == -12.f, "sg14::fixed_point test failed");
+static_assert(fixed63_0_t(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
 
 // exponent = -1
-static_assert(fp_u8<-1>(127.5).get<float>() == 127.5, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint8_t, -1>(127.5).get<float>() == 127.5, "sg14::fixed_point test failed");
 
-static_assert(fp_s8<-1>(63.5).get<float>() == 63.5, "sg14::fixed_point test failed");
-static_assert(fp_s8<-1>(-63.5).get<float>() == -63.5, "sg14::fixed_point test failed");
-
-static_assert(fp_s32<-1>::integer_digits == 30, "sg14::fixed_point test failed");
-static_assert(fp_u16<-1>::fractional_digits == 1, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, -1>(63.5).get<float>() == 63.5, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, -1>(-63.5).get<float>() == -63.5, "sg14::fixed_point test failed");
 
 // exponent == -7
-static_assert(fp_u8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
-static_assert(fp_u16<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fp_u32<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fp_u64<-7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint8_t, -7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint16_t, -8>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint32_t, -7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint64_t, -7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
 
-static_assert(fp_s8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
-static_assert(fp_s16<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
-static_assert(fp_s32<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
-static_assert(fp_s64<-7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, -7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int16_t, -7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int32_t, -7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int64_t, -7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
 
-static_assert(fp_u8<-7>(.125f).get<double>() == .125f, "sg14::fixed_point test failed");
-static_assert(fp_u16<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fp_u32<-7>(232.125f).get<double>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fp_u64<-7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint8_t, -7>(.125f).get<double>() == .125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint16_t, -8>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint32_t, -7>(232.125f).get<double>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint64_t, -7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
 
-static_assert(fp_s8<-7>(1).get<long double>() != 1.f, "sg14::fixed_point test failed");
-static_assert(fp_s8<-7>(.5).get<float>() == .5f, "sg14::fixed_point test failed");
-static_assert(fp_s8<-7>(.125f).get<long double>() == .125f, "sg14::fixed_point test failed");
-static_assert(fp_s16<-7>(123.125f).get<int>() == 123, "sg14::fixed_point test failed");
-static_assert(fp_s32<-7>(123.125f).get<long double>() == 123.125f, "sg14::fixed_point test failed");
-static_assert(fp_s64<-7>(123.125l).get<float>() == 123.125f, "sg14::fixed_point test failed");
-
-static_assert(fp_s64<-7>::integer_digits == 56, "sg14::fixed_point test failed");
-static_assert(fp_u8<-7>::fractional_digits == 7, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, -7>(1).get<long double>() != 1.f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, -7>(.5).get<float>() == .5f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, -7>(.125f).get<long double>() == .125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int16_t, -7>(123.125f).get<int>() == 123, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int32_t, -7>(123.125f).get<long double>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int64_t, -7>(123.125l).get<float>() == 123.125f, "sg14::fixed_point test failed");
 
 // exponent == 16
-static_assert(fp_u8<16>(65536).get<float>() == 65536.f, "sg14::fixed_point test failed");
-static_assert(fp_u16<16>(6553.).get<int>() == 0, "sg14::fixed_point test failed");
-static_assert(fp_u32<16>(4294967296l).get<double>() == 4294967296.f, "sg14::fixed_point test failed");
-static_assert(fp_u64<16>(1125895611875328l).get<double>() == 1125895611875328l, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint8_t, 16>(65536).get<float>() == 65536.f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint16_t, 16>(6553.).get<int>() == 0, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint32_t, 16>(4294967296l).get<double>() == 4294967296.f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint64_t, 16>(1125895611875328l).get<double>() == 1125895611875328l, "sg14::fixed_point test failed");
 
-static_assert(fp_s8<16>(-65536).get<float>() == -65536.f, "sg14::fixed_point test failed");
-static_assert(fp_s16<16>(-6553.).get<int>() == 0, "sg14::fixed_point test failed");
-static_assert(fp_s32<16>(-4294967296l).get<double>() == -4294967296.f, "sg14::fixed_point test failed");
-static_assert(fp_s64<16>(-1125895611875328l).get<double>() == -1125895611875328l, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, 16>(-65536).get<float>() == -65536.f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int16_t, 16>(-6553.).get<int>() == 0, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int32_t, 16>(-4294967296l).get<double>() == -4294967296.f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int64_t, 16>(-1125895611875328l).get<double>() == -1125895611875328l, "sg14::fixed_point test failed");
 
 // exponent = 1
-static_assert(fp_u8<1>(510).get<int>() == 510, "sg14::fixed_point test failed");
-static_assert(fp_u8<1>(511).get<int>() == 510, "sg14::fixed_point test failed");
-static_assert(fp_s8<1>(123.5).get<float>() == 122, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint8_t, 1>(510).get<int>() == 510, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint8_t, 1>(511).get<int>() == 510, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, 1>(123.5).get<float>() == 122, "sg14::fixed_point test failed");
 
-static_assert(fp_s8<1>(255).get<int>() == 254, "sg14::fixed_point test failed");
-static_assert(fp_s8<1>(254).get<int>() == 254, "sg14::fixed_point test failed");
-static_assert(fp_s8<1>(-5).get<int>() == -6, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, 1>(255).get<int>() == 254, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, 1>(254).get<int>() == 254, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::int8_t, 1>(-5).get<int>() == -6, "sg14::fixed_point test failed");
 
 // conversion between fixed_point specializations
-static_assert(fp_u8<-4>(fp_s16<-8>(1.5)).get<float>() == 1.5, "sg14::fixed_point test failed");
-static_assert(fp_u16<-8>(fp_s8<-4>(3.25)).get<float>() == 3.25, "sg14::fixed_point test failed");
-static_assert(fp_u8<4>(fp_s16<-4>(768)).get<int>() == 768, "sg14::fixed_point test failed");
-static_assert(fp_u64<-48>(fp_u32<-24>(3.141592654)).get<float>() > 3.1415923f, "sg14::fixed_point test failed");
-static_assert(fp_u64<-48>(fp_u32<-24>(3.141592654)).get<float>() < 3.1415927f, "sg14::fixed_point test failed");
+static_assert(ufixed4_4_t(fixed7_8_t(1.5)).get<float>() == 1.5, "sg14::fixed_point test failed");
+static_assert(ufixed8_8_t(fixed3_4_t(3.25)).get<float>() == 3.25, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint8_t, 4>(fixed_point<std::int16_t, -4>(768)).get<int>() == 768, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint64_t, -48>(fixed_point<std::uint32_t, -24>(3.141592654)).get<float>() > 3.1415923f, "sg14::fixed_point test failed");
+static_assert(fixed_point<std::uint64_t, -48>(fixed_point<std::uint32_t, -24>(3.141592654)).get<float>() < 3.1415927f, "sg14::fixed_point test failed");
 
 // closed_unit
-template <typename T> using cu = closed_unit<T>;
-static_assert(cu<std::uint8_t>(.5).get<double>() == .5, "sg14::closed_unit test failed");
-static_assert(cu<std::uint16_t>(.125f).get<float>() == .125f, "sg14::closed_unit test failed");
-static_assert(cu<std::uint16_t>(.640625l).get<float>() == .640625, "sg14::closed_unit test failed");
-static_assert(cu<std::uint16_t>(1.640625).get<float>() == 1.640625f, "sg14::closed_unit test failed");
-static_assert(cu<std::uint16_t>(1u).get<std::uint64_t>() == 1, "sg14::closed_unit test failed");
-static_assert(cu<std::uint16_t>(2).get<float>() != 2, "sg14::closed_unit test failed");	// out-of-range test
+static_assert(closed_unit<std::uint8_t>(.5).get<double>() == .5, "sg14::closed_unit test failed");
+static_assert(closed_unit<std::uint16_t>(.125f).get<float>() == .125f, "sg14::closed_unit test failed");
+static_assert(closed_unit<std::uint16_t>(.640625l).get<float>() == .640625, "sg14::closed_unit test failed");
+static_assert(closed_unit<std::uint16_t>(1.640625).get<float>() == 1.640625f, "sg14::closed_unit test failed");
+static_assert(closed_unit<std::uint16_t>(1u).get<std::uint64_t>() == 1, "sg14::closed_unit test failed");
+static_assert(closed_unit<std::uint16_t>(2).get<float>() != 2, "sg14::closed_unit test failed");	// out-of-range test
 
 // open_unit
-template <typename T> using ou = open_unit<T>;
-static_assert(ou<std::uint8_t>(.5).get<double>() == .5, "sg14::closed_unit test failed");
-static_assert(ou<std::uint16_t>(.125f).get<float>() == .125f, "sg14::closed_unit test failed");
-static_assert(ou<std::uint16_t>(.640625l).get<float>() == .640625, "sg14::closed_unit test failed");
-static_assert(ou<std::uint16_t>(1).get<float>() == 0, "sg14::closed_unit test failed");	// dropped bit
+static_assert(open_unit<std::uint8_t>(.5).get<double>() == .5, "sg14::closed_unit test failed");
+static_assert(open_unit<std::uint16_t>(.125f).get<float>() == .125f, "sg14::closed_unit test failed");
+static_assert(open_unit<std::uint16_t>(.640625l).get<float>() == .640625, "sg14::closed_unit test failed");
+static_assert(open_unit<std::uint16_t>(1).get<float>() == 0, "sg14::closed_unit test failed");	// dropped bit
 
 ////////////////////////////////////////////////////////////////////////////////
 // arithmetic
 
 // addition
-static_assert((fp_s32<0>(123) + fp_s32<0>(123)).get<int>() == 246, "sg14::fixed_point test failed");
-static_assert((fp_s32<-16>(123.125) + fp_s32<-16>(123.75)).get<float>() == 246.875, "sg14::fixed_point test failed");
+static_assert((fixed31_0_t(123) + fixed31_0_t(123)).get<int>() == 246, "sg14::fixed_point test failed");
+static_assert((fixed15_16_t(123.125) + fixed15_16_t(123.75)).get<float>() == 246.875, "sg14::fixed_point test failed");
 
 // subtraction
-static_assert((fp_s32<0>(999) - fp_s32<0>(369)).get<int>() == 630, "sg14::fixed_point test failed");
-static_assert((fp_s32<-16>(246.875) - fp_s32<-16>(123.75)).get<float>() == 123.125, "sg14::fixed_point test failed");
-static_assert((fp_s16<-4>(123.125) - fp_s16<-4>(246.875)).get<float>() == -123.75, "sg14::fixed_point test failed");
+static_assert((fixed31_0_t(999) - fixed31_0_t(369)).get<int>() == 630, "sg14::fixed_point test failed");
+static_assert((fixed15_16_t(246.875) - fixed15_16_t(123.75)).get<float>() == 123.125, "sg14::fixed_point test failed");
+static_assert((fixed_point<std::int16_t, -4>(123.125) - fixed_point<std::int16_t, -4>(246.875)).get<float>() == -123.75, "sg14::fixed_point test failed");
 
 // multiplication
-static_assert((fp_u8<0>(0x55) * fp_u8<0>(2)).get<int>() == 0xaa, "sg14::fixed_point test failed");
-static_assert((fp_s32<-16>(123.75) * fp_s32<-16>(44.5)).get<float>() == 5506.875, "sg14::fixed_point test failed");
+static_assert((ufixed8_0_t(0x55) * ufixed8_0_t(2)).get<int>() == 0xaa, "sg14::fixed_point test failed");
+static_assert((fixed15_16_t(123.75) * fixed15_16_t(44.5)).get<float>() == 5506.875, "sg14::fixed_point test failed");
 #if defined(_SG14_FIXED_POINT_128)
-static_assert((fp_u64<-8>(1003006) * fp_u64<-8>(7)).get<int>() == 7021042, "sg14::fixed_point test failed");
+static_assert((fixed_point<std::uint64_t, -8>(1003006) * fixed_point<std::uint64_t, -8>(7)).get<int>() == 7021042, "sg14::fixed_point test failed");
 #endif
 
 // division
-static_assert((fp_s8<-1>(63) / fp_s8<-1>(-4)).get<float>() == -15.5, "sg14::fixed_point test failed");
-static_assert((fp_s8<1>(-255) / fp_s8<1>(-8)).get<int>() == 32, "sg14::fixed_point test failed");
-static_assert((fp_s32<0>(-999) / fp_s32<0>(3)).get<int>() == -333, "sg14::fixed_point test failed");
+static_assert((fixed_point<std::int8_t, -1>(63) / fixed_point<std::int8_t, -1>(-4)).get<float>() == -15.5, "sg14::fixed_point test failed");
+static_assert((fixed_point<std::int8_t, 1>(-255) / fixed_point<std::int8_t, 1>(-8)).get<int>() == 32, "sg14::fixed_point test failed");
+static_assert((fixed31_0_t(-999) / fixed31_0_t(3)).get<int>() == -333, "sg14::fixed_point test failed");
 #if defined(_SG14_FIXED_POINT_128)
-static_assert((fp_u64<-8>(65535) / fp_u64<-8>(256)).get<int>() == 255, "sg14::fixed_point test failed");
+static_assert((fixed_point<std::uint64_t, -8>(65535) / fixed_point<std::uint64_t, -8>(256)).get<int>() == 255, "sg14::fixed_point test failed");
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -226,7 +203,7 @@ static_assert(fixed_point_mul_result_t<std::int32_t, -25>::integer_digits == 12,
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::safe_multiply
 
-static_assert(safe_multiply(fp_s16<-8>(127), fp_s16<-8>(127)).get<int>() == 16129, "sg14::safe_multiply test failed");
+static_assert(safe_multiply(fixed7_8_t(127), fixed7_8_t(127)).get<int>() == 16129, "sg14::safe_multiply test failed");
 static_assert(safe_multiply<std::uint8_t, -4>(15.9375, 15.9375).get<int>() == 254, "sg14::safe_multiply test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -238,43 +215,43 @@ static_assert(fixed_point_add_result_t<std::int32_t, -25, 4>::integer_digits == 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::safe_add
 
-static_assert(safe_add(fp_u8<-1>(127), fp_u8<-1>(127)).get<int>() == 254, "sg14::safe_add test failed");
+static_assert(safe_add(fixed_point<std::uint8_t, -1>(127), fixed_point<std::uint8_t, -1>(127)).get<int>() == 254, "sg14::safe_add test failed");
 static_assert(safe_add<std::uint8_t, -4>(15, 13).get<int>() == 28, "sg14::safe_add test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::abs
 
-static_assert(abs(fp_s8<0>(66)).get<int>() == 66, "sg14::sqrt test failed");
-static_assert(abs(fp_s8<0>(-123)).get<int>() == 123, "sg14::sqrt test failed");
-static_assert(abs(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
-static_assert(abs(fp_s64<0>(-9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
+static_assert(abs(fixed7_0_t(66)).get<int>() == 66, "sg14::sqrt test failed");
+static_assert(abs(fixed7_0_t(-123)).get<int>() == 123, "sg14::sqrt test failed");
+static_assert(abs(fixed63_0_t(9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
+static_assert(abs(fixed63_0_t(-9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::sqrt
 
-static_assert(sqrt(fp_u8<0>(225)).get<int>() == 15, "sg14::sqrt test failed");
-static_assert(sqrt(fp_s8<0>(81)).get<int>() == 9, "sg14::sqrt test failed");
+static_assert(sqrt(ufixed8_0_t(225)).get<int>() == 15, "sg14::sqrt test failed");
+static_assert(sqrt(fixed7_0_t(81)).get<int>() == 9, "sg14::sqrt test failed");
 
-static_assert(sqrt(fp_u8<-1>(4)).get<int>() == 2, "sg14::sqrt test failed");
-static_assert(sqrt(fp_s8<-2>(9)).get<int>() == 3, "sg14::sqrt test failed");
+static_assert(sqrt(fixed_point<std::uint8_t, -1>(4)).get<int>() == 2, "sg14::sqrt test failed");
+static_assert(sqrt(fixed_point<std::int8_t, -2>(9)).get<int>() == 3, "sg14::sqrt test failed");
 
-static_assert(sqrt(fp_u8<-4>(4)).get<int>() == 2, "sg14::sqrt test failed");
-static_assert(sqrt(fp_s32<-24>(3.141592654)).get<float>() > 1.7724537849426, "sg14::sqrt test failed");
-static_assert(sqrt(fp_s32<-24>(3.141592654)).get<float>() < 1.7724537849427, "sg14::sqrt test failed");
+static_assert(sqrt(ufixed4_4_t(4)).get<int>() == 2, "sg14::sqrt test failed");
+static_assert(sqrt(fixed_point<std::int32_t, -24>(3.141592654)).get<float>() > 1.7724537849426, "sg14::sqrt test failed");
+static_assert(sqrt(fixed_point<std::int32_t, -24>(3.141592654)).get<float>() < 1.7724537849427, "sg14::sqrt test failed");
 #if defined(_SG14_FIXED_POINT_128)
-static_assert(sqrt(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 3037000499, "sg14::sqrt test failed");
+static_assert(sqrt(fixed63_0_t(9223372036854775807)).get<std::int64_t>() == 3037000499, "sg14::sqrt test failed");
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::lerp
 
-static_assert(lerp(fp_u8<-7>(1), fp_u8<-7>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
-static_assert(lerp(fp_u16<-7>(.125), fp_u16<-7>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
-static_assert(lerp(fp_u32<-16>(42123.51323), fp_u32<-16>(432.9191), .812).get<unsigned>() == 8270, "sg14::lerp test failed");
+static_assert(lerp(ufixed1_7_t(1), ufixed1_7_t(0), .5).get<float>() == .5f, "sg14::lerp test failed");
+static_assert(lerp(ufixed8_8_t(.125), ufixed8_8_t(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
+static_assert(lerp(ufixed16_16_t(42123.51323), ufixed16_16_t(432.9191), .812).get<unsigned>() == 8270, "sg14::lerp test failed");
 
-static_assert(lerp(fp_s8<-6>(1), fp_s8<-6>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
-static_assert(lerp(fp_s16<-10>(.125), fp_s16<-10>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
-static_assert(lerp(fp_s32<-6>(.125), fp_s32<-6>(.625), .25).get<float>() == .25f, "sg14::lerp test failed");
+static_assert(lerp(fixed_point<std::int8_t, -6>(1), fixed_point<std::int8_t, -6>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
+static_assert(lerp(fixed_point<std::int16_t, -10>(.125), fixed_point<std::int16_t, -10>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
+static_assert(lerp(fixed_point<std::int32_t, -6>(.125), fixed_point<std::int32_t, -6>(.625), .25).get<float>() == .25f, "sg14::lerp test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // fixed_point specializations

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -224,10 +224,22 @@ static_assert(sg14::fixed_point_mul_result_t<std::uint8_t, -4>::integer_digits =
 static_assert(sg14::fixed_point_mul_result_t<std::int32_t, -25>::integer_digits == 12, "sg14::fixed_point_by_integer_digits_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
+// sg14::safe_multiply
+
+static_assert(sg14::safe_multiply(fp_s16<-8>(127), fp_s16<-8>(127)).get<int>() == 16129, "sg14::safe_multiply test failed");
+static_assert(sg14::safe_multiply<std::uint8_t, -4>(15.9375, 15.9375).get<int>() == 254, "sg14::safe_multiply test failed");
+
+////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_add_result_t
 
 static_assert(sg14::fixed_point_add_result_t<std::uint8_t, -4>::integer_digits == 5, "sg14::fixed_point_by_integer_digits_t test failed");
 static_assert(sg14::fixed_point_add_result_t<std::int32_t, -25, 4>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// sg14::safe_add
+
+static_assert(sg14::safe_add(fp_u8<-1>(127), fp_u8<-1>(127)).get<int>() == 254, "sg14::safe_add test failed");
+static_assert(sg14::safe_add<std::uint8_t, -4>(15, 13).get<int>() == 28, "sg14::safe_add test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::abs

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -275,3 +275,122 @@ static_assert(lerp(fp_u32<-16>(42123.51323), fp_u32<-16>(432.9191), .812).get<un
 static_assert(lerp(fp_s8<-6>(1), fp_s8<-6>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
 static_assert(lerp(fp_s16<-10>(.125), fp_s16<-10>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
 static_assert(lerp(fp_s32<-6>(.125), fp_s32<-6>(.625), .25).get<float>() == .25f, "sg14::lerp test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// fixed_point specializations
+
+// integer_digits
+static_assert(fixed0_7_t::integer_digits == 0, "fixed_point specializations test failed");
+static_assert(fixed1_6_t::integer_digits == 1, "fixed_point specializations test failed");
+static_assert(fixed3_4_t::integer_digits == 3, "fixed_point specializations test failed");
+static_assert(fixed4_3_t::integer_digits == 4, "fixed_point specializations test failed");
+static_assert(fixed7_0_t::integer_digits == 7, "fixed_point specializations test failed");
+
+static_assert(ufixed0_8_t::integer_digits == 0, "fixed_point specializations test failed");
+static_assert(ufixed1_7_t::integer_digits == 1, "fixed_point specializations test failed");
+static_assert(ufixed4_4_t::integer_digits == 4, "fixed_point specializations test failed");
+static_assert(ufixed8_0_t::integer_digits == 8, "fixed_point specializations test failed");
+
+static_assert(fixed0_15_t::integer_digits == 0, "fixed_point specializations test failed");
+static_assert(fixed1_14_t::integer_digits == 1, "fixed_point specializations test failed");
+static_assert(fixed7_8_t::integer_digits == 7, "fixed_point specializations test failed");
+static_assert(fixed8_7_t::integer_digits == 8, "fixed_point specializations test failed");
+static_assert(fixed15_0_t::integer_digits == 15, "fixed_point specializations test failed");
+
+static_assert(ufixed0_16_t::integer_digits == 0, "fixed_point specializations test failed");
+static_assert(ufixed1_15_t::integer_digits == 1, "fixed_point specializations test failed");
+static_assert(ufixed8_8_t::integer_digits == 8, "fixed_point specializations test failed");
+static_assert(ufixed16_0_t::integer_digits == 16, "fixed_point specializations test failed");
+
+static_assert(fixed0_31_t::integer_digits == 0, "fixed_point specializations test failed");
+static_assert(fixed1_30_t::integer_digits == 1, "fixed_point specializations test failed");
+static_assert(fixed15_16_t::integer_digits == 15, "fixed_point specializations test failed");
+static_assert(fixed16_15_t::integer_digits == 16, "fixed_point specializations test failed");
+static_assert(fixed31_0_t::integer_digits == 31, "fixed_point specializations test failed");
+
+static_assert(ufixed0_32_t::integer_digits == 0, "fixed_point specializations test failed");
+static_assert(ufixed1_31_t::integer_digits == 1, "fixed_point specializations test failed");
+static_assert(ufixed16_16_t::integer_digits == 16, "fixed_point specializations test failed");
+static_assert(ufixed32_0_t::integer_digits == 32, "fixed_point specializations test failed");
+
+static_assert(fixed0_63_t::integer_digits == 0, "fixed_point specializations test failed");
+static_assert(fixed1_62_t::integer_digits == 1, "fixed_point specializations test failed");
+static_assert(fixed31_32_t::integer_digits == 31, "fixed_point specializations test failed");
+static_assert(fixed32_31_t::integer_digits == 32, "fixed_point specializations test failed");
+static_assert(fixed63_0_t::integer_digits == 63, "fixed_point specializations test failed");
+
+static_assert(ufixed0_64_t::integer_digits == 0, "fixed_point specializations test failed");
+static_assert(ufixed1_63_t::integer_digits == 1, "fixed_point specializations test failed");
+static_assert(ufixed32_32_t::integer_digits == 32, "fixed_point specializations test failed");
+static_assert(ufixed64_0_t::integer_digits == 64, "fixed_point specializations test failed");
+
+#if defined(_SG14_FIXED_POINT_128)
+static_assert(fixed0_127_t::integer_digits == 0, "fixed_point specializations test failed");
+static_assert(fixed1_126_t::integer_digits == 1, "fixed_point specializations test failed");
+static_assert(fixed63_64_t::integer_digits == 63, "fixed_point specializations test failed");
+static_assert(fixed64_63_t::integer_digits == 64, "fixed_point specializations test failed");
+static_assert(fixed127_0_t::integer_digits == 127, "fixed_point specializations test failed");
+
+static_assert(ufixed0_128_t::integer_digits == 0, "fixed_point specializations test failed");
+static_assert(ufixed1_127_t::integer_digits == 1, "fixed_point specializations test failed");
+static_assert(ufixed64_64_t::integer_digits == 64, "fixed_point specializations test failed");
+static_assert(ufixed128_0_t::integer_digits == 128, "fixed_point specializations test failed");
+#endif
+
+// fractional_digits
+static_assert(fixed0_7_t::fractional_digits == 7, "fixed_point specializations test failed");
+static_assert(fixed1_6_t::fractional_digits == 6, "fixed_point specializations test failed");
+static_assert(fixed3_4_t::fractional_digits == 4, "fixed_point specializations test failed");
+static_assert(fixed4_3_t::fractional_digits == 3, "fixed_point specializations test failed");
+static_assert(fixed7_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+
+static_assert(ufixed0_8_t::fractional_digits == 8, "fixed_point specializations test failed");
+static_assert(ufixed1_7_t::fractional_digits == 7, "fixed_point specializations test failed");
+static_assert(ufixed4_4_t::fractional_digits == 4, "fixed_point specializations test failed");
+static_assert(ufixed8_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+
+static_assert(fixed0_15_t::fractional_digits == 15, "fixed_point specializations test failed");
+static_assert(fixed1_14_t::fractional_digits == 14, "fixed_point specializations test failed");
+static_assert(fixed7_8_t::fractional_digits == 8, "fixed_point specializations test failed");
+static_assert(fixed8_7_t::fractional_digits == 7, "fixed_point specializations test failed");
+static_assert(fixed15_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+
+static_assert(ufixed0_16_t::fractional_digits == 16, "fixed_point specializations test failed");
+static_assert(ufixed1_15_t::fractional_digits == 15, "fixed_point specializations test failed");
+static_assert(ufixed8_8_t::fractional_digits == 8, "fixed_point specializations test failed");
+static_assert(ufixed16_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+
+static_assert(fixed0_31_t::fractional_digits == 31, "fixed_point specializations test failed");
+static_assert(fixed1_30_t::fractional_digits == 30, "fixed_point specializations test failed");
+static_assert(fixed15_16_t::fractional_digits == 16, "fixed_point specializations test failed");
+static_assert(fixed16_15_t::fractional_digits == 15, "fixed_point specializations test failed");
+static_assert(fixed31_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+
+static_assert(ufixed0_32_t::fractional_digits == 32, "fixed_point specializations test failed");
+static_assert(ufixed1_31_t::fractional_digits == 31, "fixed_point specializations test failed");
+static_assert(ufixed16_16_t::fractional_digits == 16, "fixed_point specializations test failed");
+static_assert(ufixed32_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+
+static_assert(fixed0_63_t::fractional_digits == 63, "fixed_point specializations test failed");
+static_assert(fixed1_62_t::fractional_digits == 62, "fixed_point specializations test failed");
+static_assert(fixed31_32_t::fractional_digits == 32, "fixed_point specializations test failed");
+static_assert(fixed32_31_t::fractional_digits == 31, "fixed_point specializations test failed");
+static_assert(fixed63_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+
+static_assert(ufixed0_64_t::fractional_digits == 64, "fixed_point specializations test failed");
+static_assert(ufixed1_63_t::fractional_digits == 63, "fixed_point specializations test failed");
+static_assert(ufixed32_32_t::fractional_digits == 32, "fixed_point specializations test failed");
+static_assert(ufixed64_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+
+#if defined(_SG14_FIXED_POINT_128)
+static_assert(fixed0_127_t::fractional_digits == 127, "fixed_point specializations test failed");
+static_assert(fixed1_126_t::fractional_digits == 126, "fixed_point specializations test failed");
+static_assert(fixed63_64_t::fractional_digits == 64, "fixed_point specializations test failed");
+static_assert(fixed64_63_t::fractional_digits == 64, "fixed_point specializations test failed");
+static_assert(fixed127_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+
+static_assert(ufixed0_128_t::fractional_digits == 128, "fixed_point specializations test failed");
+static_assert(ufixed1_127_t::fractional_digits == 127, "fixed_point specializations test failed");
+static_assert(ufixed64_64_t::fractional_digits == 64, "fixed_point specializations test failed");
+static_assert(ufixed128_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+#endif

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -202,76 +202,76 @@ static_assert((fp_u64<-8>(65535) / fp_u64<-8>(256)).get<int>() == 255, "sg14::fi
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_promotion_t
 
-static_assert(std::is_same<sg14::fixed_point_promotion_t<std::int8_t, -4>, sg14::fixed_point<std::int16_t, -8>>::value, "sg14::promotion test failed");
-static_assert(std::is_same<sg14::fixed_point_promotion_t<std::uint32_t, 44>, sg14::fixed_point<std::uint64_t, 88>>::value, "sg14::promotion test failed");
+static_assert(std::is_same<fixed_point_promotion_t<std::int8_t, -4>, fixed_point<std::int16_t, -8>>::value, "sg14::promotion test failed");
+static_assert(std::is_same<fixed_point_promotion_t<std::uint32_t, 44>, fixed_point<std::uint64_t, 88>>::value, "sg14::promotion test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_demotion_t
 
-static_assert(std::is_same<sg14::fixed_point<std::int8_t, -4>, sg14::fixed_point_demotion_t<std::int16_t, -8>>::value, "sg14::promotion test failed");
-static_assert(std::is_same<sg14::fixed_point<std::uint32_t, 44>, sg14::fixed_point_demotion_t<std::uint64_t, 88>>::value, "sg14::promotion test failed");
+static_assert(std::is_same<fixed_point<std::int8_t, -4>, fixed_point_demotion_t<std::int16_t, -8>>::value, "sg14::promotion test failed");
+static_assert(std::is_same<fixed_point<std::uint32_t, 44>, fixed_point_demotion_t<std::uint64_t, 88>>::value, "sg14::promotion test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_by_integer_digits_t
 
-static_assert(sg14::fixed_point_by_integer_digits_t<std::uint8_t, 8>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
-static_assert(sg14::fixed_point_by_integer_digits_t<std::int32_t, 27>::integer_digits == 27, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(fixed_point_by_integer_digits_t<std::uint8_t, 8>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(fixed_point_by_integer_digits_t<std::int32_t, 27>::integer_digits == 27, "sg14::fixed_point_by_integer_digits_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_mul_result_t
 
-static_assert(sg14::fixed_point_mul_result_t<std::uint8_t, -4>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
-static_assert(sg14::fixed_point_mul_result_t<std::int32_t, -25>::integer_digits == 12, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(fixed_point_mul_result_t<std::uint8_t, -4>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(fixed_point_mul_result_t<std::int32_t, -25>::integer_digits == 12, "sg14::fixed_point_by_integer_digits_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::safe_multiply
 
-static_assert(sg14::safe_multiply(fp_s16<-8>(127), fp_s16<-8>(127)).get<int>() == 16129, "sg14::safe_multiply test failed");
-static_assert(sg14::safe_multiply<std::uint8_t, -4>(15.9375, 15.9375).get<int>() == 254, "sg14::safe_multiply test failed");
+static_assert(safe_multiply(fp_s16<-8>(127), fp_s16<-8>(127)).get<int>() == 16129, "sg14::safe_multiply test failed");
+static_assert(safe_multiply<std::uint8_t, -4>(15.9375, 15.9375).get<int>() == 254, "sg14::safe_multiply test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_add_result_t
 
-static_assert(sg14::fixed_point_add_result_t<std::uint8_t, -4>::integer_digits == 5, "sg14::fixed_point_by_integer_digits_t test failed");
-static_assert(sg14::fixed_point_add_result_t<std::int32_t, -25, 4>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(fixed_point_add_result_t<std::uint8_t, -4>::integer_digits == 5, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(fixed_point_add_result_t<std::int32_t, -25, 4>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::safe_add
 
-static_assert(sg14::safe_add(fp_u8<-1>(127), fp_u8<-1>(127)).get<int>() == 254, "sg14::safe_add test failed");
-static_assert(sg14::safe_add<std::uint8_t, -4>(15, 13).get<int>() == 28, "sg14::safe_add test failed");
+static_assert(safe_add(fp_u8<-1>(127), fp_u8<-1>(127)).get<int>() == 254, "sg14::safe_add test failed");
+static_assert(safe_add<std::uint8_t, -4>(15, 13).get<int>() == 28, "sg14::safe_add test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::abs
 
-static_assert(sg14::abs(fp_s8<0>(66)).get<int>() == 66, "sg14::sqrt test failed");
-static_assert(sg14::abs(fp_s8<0>(-123)).get<int>() == 123, "sg14::sqrt test failed");
-static_assert(sg14::abs(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
-static_assert(sg14::abs(fp_s64<0>(-9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
+static_assert(abs(fp_s8<0>(66)).get<int>() == 66, "sg14::sqrt test failed");
+static_assert(abs(fp_s8<0>(-123)).get<int>() == 123, "sg14::sqrt test failed");
+static_assert(abs(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
+static_assert(abs(fp_s64<0>(-9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::sqrt
 
-static_assert(sg14::sqrt(fp_u8<0>(225)).get<int>() == 15, "sg14::sqrt test failed");
-static_assert(sg14::sqrt(fp_s8<0>(81)).get<int>() == 9, "sg14::sqrt test failed");
+static_assert(sqrt(fp_u8<0>(225)).get<int>() == 15, "sg14::sqrt test failed");
+static_assert(sqrt(fp_s8<0>(81)).get<int>() == 9, "sg14::sqrt test failed");
 
-static_assert(sg14::sqrt(fp_u8<-1>(4)).get<int>() == 2, "sg14::sqrt test failed");
-static_assert(sg14::sqrt(fp_s8<-2>(9)).get<int>() == 3, "sg14::sqrt test failed");
+static_assert(sqrt(fp_u8<-1>(4)).get<int>() == 2, "sg14::sqrt test failed");
+static_assert(sqrt(fp_s8<-2>(9)).get<int>() == 3, "sg14::sqrt test failed");
 
-static_assert(sg14::sqrt(fp_u8<-4>(4)).get<int>() == 2, "sg14::sqrt test failed");
-static_assert(sg14::sqrt(fp_s32<-24>(3.141592654)).get<float>() > 1.7724537849426, "sg14::sqrt test failed");
-static_assert(sg14::sqrt(fp_s32<-24>(3.141592654)).get<float>() < 1.7724537849427, "sg14::sqrt test failed");
+static_assert(sqrt(fp_u8<-4>(4)).get<int>() == 2, "sg14::sqrt test failed");
+static_assert(sqrt(fp_s32<-24>(3.141592654)).get<float>() > 1.7724537849426, "sg14::sqrt test failed");
+static_assert(sqrt(fp_s32<-24>(3.141592654)).get<float>() < 1.7724537849427, "sg14::sqrt test failed");
 #if defined(_SG14_FIXED_POINT_128)
-static_assert(sg14::sqrt(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 3037000499, "sg14::sqrt test failed");
+static_assert(sqrt(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 3037000499, "sg14::sqrt test failed");
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::lerp
 
-static_assert(sg14::lerp(fp_u8<-7>(1), fp_u8<-7>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
-static_assert(sg14::lerp(fp_u16<-7>(.125), fp_u16<-7>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
-static_assert(sg14::lerp(fp_u32<-16>(42123.51323), fp_u32<-16>(432.9191), .812).get<unsigned>() == 8270, "sg14::lerp test failed");
+static_assert(lerp(fp_u8<-7>(1), fp_u8<-7>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
+static_assert(lerp(fp_u16<-7>(.125), fp_u16<-7>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
+static_assert(lerp(fp_u32<-16>(42123.51323), fp_u32<-16>(432.9191), .812).get<unsigned>() == 8270, "sg14::lerp test failed");
 
-static_assert(sg14::lerp(fp_s8<-6>(1), fp_s8<-6>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
-static_assert(sg14::lerp(fp_s16<-10>(.125), fp_s16<-10>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
-static_assert(sg14::lerp(fp_s32<-6>(.125), fp_s32<-6>(.625), .25).get<float>() == .25f, "sg14::lerp test failed");
+static_assert(lerp(fp_s8<-6>(1), fp_s8<-6>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
+static_assert(lerp(fp_s16<-10>(.125), fp_s16<-10>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
+static_assert(lerp(fp_s32<-6>(.125), fp_s32<-6>(.625), .25).get<float>() == .25f, "sg14::lerp test failed");

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -363,7 +363,7 @@ static_assert(ufixed64_0_t::fractional_digits == 0, "fixed_point specializations
 static_assert(fixed0_127_t::fractional_digits == 127, "fixed_point specializations test failed");
 static_assert(fixed1_126_t::fractional_digits == 126, "fixed_point specializations test failed");
 static_assert(fixed63_64_t::fractional_digits == 64, "fixed_point specializations test failed");
-static_assert(fixed64_63_t::fractional_digits == 64, "fixed_point specializations test failed");
+static_assert(fixed64_63_t::fractional_digits == 63, "fixed_point specializations test failed");
 static_assert(fixed127_0_t::fractional_digits == 0, "fixed_point specializations test failed");
 
 static_assert(ufixed0_128_t::fractional_digits == 128, "fixed_point specializations test failed");

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -165,7 +165,7 @@ static_assert((fp_s16<-4>(123.125) - fp_s16<-4>(246.875)).get<float>() == -123.7
 // multiplication
 static_assert((fp_u8<0>(0x55) * fp_u8<0>(2)).get<int>() == 0xaa, "sg14::fixed_point test failed");
 static_assert((fp_s32<-16>(123.75) * fp_s32<-16>(44.5)).get<float>() == 5506.875, "sg14::fixed_point test failed");
-#if defined(_SG14_FIXED_POINT_64)
+#if defined(_SG14_FIXED_POINT_128)
 static_assert((fp_u64<-8>(1003006) * fp_u64<-8>(7)).get<int>() == 7021042, "sg14::fixed_point test failed");
 #endif
 
@@ -173,7 +173,7 @@ static_assert((fp_u64<-8>(1003006) * fp_u64<-8>(7)).get<int>() == 7021042, "sg14
 static_assert((fp_s8<-1>(63) / fp_s8<-1>(-4)).get<float>() == -15.5, "sg14::fixed_point test failed");
 static_assert((fp_s8<1>(-255) / fp_s8<1>(-8)).get<int>() == 32, "sg14::fixed_point test failed");
 static_assert((fp_s32<0>(-999) / fp_s32<0>(3)).get<int>() == -333, "sg14::fixed_point test failed");
-#if defined(_SG14_FIXED_POINT_64)
+#if defined(_SG14_FIXED_POINT_128)
 static_assert((fp_u64<-8>(65535) / fp_u64<-8>(256)).get<int>() == 255, "sg14::fixed_point test failed");
 #endif
 
@@ -197,7 +197,7 @@ static_assert(sg14::sqrt(fp_s8<-2>(9)).get<int>() == 3, "sg14::sqrt test failed"
 static_assert(sg14::sqrt(fp_u8<-4>(4)).get<int>() == 2, "sg14::sqrt test failed");
 static_assert(sg14::sqrt(fp_s32<-24>(3.141592654)).get<float>() > 1.7724537849426, "sg14::sqrt test failed");
 static_assert(sg14::sqrt(fp_s32<-24>(3.141592654)).get<float>() < 1.7724537849427, "sg14::sqrt test failed");
-#if defined(_SG14_FIXED_POINT_64)
+#if defined(_SG14_FIXED_POINT_128)
 static_assert(sg14::sqrt(fp_s64<0>(9223372036854775807)).get<std::int64_t>() == 3037000499, "sg14::sqrt test failed");
 #endif
 

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -91,11 +91,17 @@ static_assert(fp_s16<0>(-12.34f).get<long double>() == -12.f, "sg14::fixed_point
 static_assert(fp_s32<0>(-12.34f).get<float>() == -12.f, "sg14::fixed_point test failed");
 static_assert(fp_s64<0>(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
 
+static_assert(fp_s8<0>::integer_digits == 7, "sg14::fixed_point test failed");
+static_assert(fp_u64<0>::fractional_digits == 0, "sg14::fixed_point test failed");
+
 // exponent = -1
 static_assert(fp_u8<-1>(127.5).get<float>() == 127.5, "sg14::fixed_point test failed");
 
 static_assert(fp_s8<-1>(63.5).get<float>() == 63.5, "sg14::fixed_point test failed");
 static_assert(fp_s8<-1>(-63.5).get<float>() == -63.5, "sg14::fixed_point test failed");
+
+static_assert(fp_s32<-1>::integer_digits == 30, "sg14::fixed_point test failed");
+static_assert(fp_u16<-1>::fractional_digits == 1, "sg14::fixed_point test failed");
 
 // exponent == -7
 static_assert(fp_u8<-7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
@@ -119,6 +125,9 @@ static_assert(fp_s8<-7>(.125f).get<long double>() == .125f, "sg14::fixed_point t
 static_assert(fp_s16<-7>(123.125f).get<int>() == 123, "sg14::fixed_point test failed");
 static_assert(fp_s32<-7>(123.125f).get<long double>() == 123.125f, "sg14::fixed_point test failed");
 static_assert(fp_s64<-7>(123.125l).get<float>() == 123.125f, "sg14::fixed_point test failed");
+
+static_assert(fp_s64<-7>::integer_digits == 56, "sg14::fixed_point test failed");
+static_assert(fp_u8<-7>::fractional_digits == 7, "sg14::fixed_point test failed");
 
 // exponent == 16
 static_assert(fp_u8<16>(65536).get<float>() == 65536.f, "sg14::fixed_point test failed");

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -49,6 +49,19 @@ static_assert(_impl::pow2<long double, 10>() == 1024, "sg14::_impl::pow2 test fa
 static_assert(_impl::pow2<float, 20>() == 1048576, "sg14::_impl::pow2 test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
+// sg14::_impl::capacity
+
+static_assert(_impl::capacity<0>::value == 0, "sg14::_impl::capacity test failed");
+static_assert(_impl::capacity<1>::value == 1, "sg14::_impl::capacity test failed");
+static_assert(_impl::capacity<2>::value == 2, "sg14::_impl::capacity test failed");
+static_assert(_impl::capacity<3>::value == 2, "sg14::_impl::capacity test failed");
+static_assert(_impl::capacity<4>::value == 3, "sg14::_impl::capacity test failed");
+static_assert(_impl::capacity<7>::value == 3, "sg14::_impl::capacity test failed");
+static_assert(_impl::capacity<8>::value == 4, "sg14::_impl::capacity test failed");
+static_assert(_impl::capacity<15>::value == 4, "sg14::_impl::capacity test failed");
+static_assert(_impl::capacity<16>::value == 5, "sg14::_impl::capacity test failed");
+
+////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point
 

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -178,6 +178,18 @@ static_assert((fp_u64<-8>(65535) / fp_u64<-8>(256)).get<int>() == 255, "sg14::fi
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
+// sg14::promotion
+
+static_assert(std::is_same<sg14::fixed_point_promotion_t<std::int8_t, -4>, sg14::fixed_point<std::int16_t, -8>>::value, "sg14::promotion test failed");
+static_assert(std::is_same<sg14::fixed_point_promotion_t<std::uint32_t, 44>, sg14::fixed_point<std::uint64_t, 88>>::value, "sg14::promotion test failed");
+
+////////////////////////////////////////////////////////////////////////////////
+// sg14::demotion
+
+static_assert(std::is_same<sg14::fixed_point<std::int8_t, -4>, sg14::fixed_point_demotion_t<std::int16_t, -8>>::value, "sg14::promotion test failed");
+static_assert(std::is_same<sg14::fixed_point<std::uint32_t, 44>, sg14::fixed_point_demotion_t<std::uint64_t, 88>>::value, "sg14::promotion test failed");
+
+////////////////////////////////////////////////////////////////////////////////
 // sg14::abs
 
 static_assert(sg14::abs(fp_s8<0>(66)).get<int>() == 66, "sg14::sqrt test failed");


### PR DESCRIPTION
# Promotion / Safe Arithmetic Operations
The main difference arising from this branch is a set of aliases and functions intended to make it easier to perform addition and multiplication on `fixed_point` objects without the chance of overflow. 

Two ways to preserve bits are:

1. REPR_TYPE - to increase the capacity of the underlying built-in type used to represent the fixed-point value - as done by `sg14::promote` (and undone by `sg14::demote`) or
2. EXPONENT - to adjust the exponent appropriately - as done by `sg14::safe_add` and `sg14::safe_multiply`.

The former is suitable for ensuring that every last bit of precision possible is preserved once the value is converted back to the original type. It is equivalent to converting to double-precision types while performing calculations.

The later loses its less significant bits but requires far less higher-capacity intermediate storage. It is equivalent to remaining at single-precision floating-point type for the duration of a calculation.

This follows through with ideas discussed in [this post](https://groups.google.com/a/isocpp.org/d/msg/sg14/1w5eiJsyT2Q/gJSKvoWmTsMJ).

# Common Type Aliases
A number of aliases to commonly-used fixed-point specializations are defined. This is partly to see how useful people find them if they are used to the typical I:F fixed-point notation. For example, `sg14::fixed15_16_t` is a ready-rolled type representing a signed 15:16 fixed-point type.

Discussion of these aliases can be found in the same thread [here](https://groups.google.com/a/isocpp.org/d/msg/sg14/1w5eiJsyT2Q/JfC2aN_cBAAJ).