### PR TITLE
Safe fn fixes

### DIFF
--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -607,12 +607,29 @@ namespace sg14
 		REPR_TYPE,
 		fixed_point<REPR_TYPE, EXPONENT>::integer_digits + _impl::capacity<N - 1>::value>;
 
-	template <typename REPR_TYPE, int EXPONENT>
-	fixed_point_add_result_t<REPR_TYPE, EXPONENT>
-	constexpr safe_add(fixed_point<REPR_TYPE, EXPONENT> const & addend1, fixed_point<REPR_TYPE, EXPONENT> const & addend2)
+	namespace _impl
 	{
-		using output_type = fixed_point_add_result_t<REPR_TYPE, EXPONENT>;
-		return static_cast<output_type>(addend1) + static_cast<output_type>(addend2);
+		template <typename RESULT_TYPE, typename REPR_TYPE, int EXPONENT, typename HEAD>
+		constexpr RESULT_TYPE add(HEAD const & addend_head)
+		{
+			static_assert(std::is_same<fixed_point<REPR_TYPE, EXPONENT>, HEAD>::value, "mismatched safe_add parameters");
+			return static_cast<RESULT_TYPE>(addend_head);
+		}
+
+		template <typename RESULT_TYPE, typename REPR_TYPE, int EXPONENT, typename HEAD, typename ... TAIL>
+		constexpr RESULT_TYPE add(HEAD const & addend_head, TAIL const & ... addend_tail)
+		{
+			static_assert(std::is_same<fixed_point<REPR_TYPE, EXPONENT>, HEAD>::value, "mismatched safe_add parameters");
+			return add<RESULT_TYPE, REPR_TYPE, EXPONENT, TAIL ...>(addend_tail ...) + static_cast<RESULT_TYPE>(addend_head);
+		}
+	}
+
+	template <typename REPR_TYPE, int EXPONENT, typename ... TAIL>
+	fixed_point_add_result_t<REPR_TYPE, EXPONENT, sizeof...(TAIL) + 1>
+	constexpr safe_add(fixed_point<REPR_TYPE, EXPONENT> const & addend1, TAIL const & ... addend_tail)
+	{
+		using output_type = fixed_point_add_result_t<REPR_TYPE, EXPONENT, sizeof...(TAIL) + 1>;
+		return _impl::add<output_type, REPR_TYPE, EXPONENT>(addend1, addend_tail ...);
 	}
 
 	////////////////////////////////////////////////////////////////////////////////

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -594,7 +594,7 @@ namespace sg14
 	{
 		using output_type = fixed_point_mul_result_t<REPR_TYPE, EXPONENT>;
 		using next_type = _impl::next_size_t<REPR_TYPE>;
-		return output_type(_impl::shift_left<EXPONENT * 2, REPR_TYPE>(next_type(factor1.data()) * factor2.data()));
+		return output_type(_impl::shift_left<EXPONENT * 2, next_type>(next_type(factor1.data()) * factor2.data()));
 	}
 
 	////////////////////////////////////////////////////////////////////////////////

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -221,6 +221,7 @@ static_assert(fixed_point_add_result_t<std::int32_t, -25, 4>::integer_digits == 
 
 static_assert(safe_add(fixed_point<std::uint8_t, -1>(127), fixed_point<std::uint8_t, -1>(127)).get<int>() == 254, "sg14::safe_add test failed");
 static_assert(safe_add<std::uint8_t, -4>(15, 13).get<int>() == 28, "sg14::safe_add test failed");
+static_assert(safe_add(ufixed4_4_t(15.5), ufixed4_4_t(14.25), ufixed4_4_t(13.5)).get<float>() == 43.25, "sg14::safe_add test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::abs

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -199,6 +199,7 @@ static_assert(fixed_point_by_integer_digits_t<std::int32_t, 27>::integer_digits 
 
 static_assert(fixed_point_mul_result_t<std::uint8_t, -4>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
 static_assert(fixed_point_mul_result_t<std::int32_t, -25>::integer_digits == 12, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(fixed_point_mul_result_t<std::uint8_t, 0>::integer_digits == 16, "sg14::fixed_point_by_integer_digits_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::safe_multiply
@@ -206,6 +207,8 @@ static_assert(fixed_point_mul_result_t<std::int32_t, -25>::integer_digits == 12,
 static_assert(safe_multiply(fixed7_8_t(127), fixed7_8_t(127)).get<int>() == 16129, "sg14::safe_multiply test failed");
 static_assert(safe_multiply<std::uint8_t, -4>(15.9375, 15.9375).get<int>() == 254, "sg14::safe_multiply test failed");
 static_assert(safe_multiply(ufixed4_4_t(0.0625), ufixed4_4_t(0.0625)).get<float>() == 0, "sg14::safe_multiply test failed");
+static_assert(safe_multiply(ufixed8_0_t(1), ufixed8_0_t(1)).get<float>() == 0, "sg14::safe_multiply test failed");
+static_assert(safe_multiply(ufixed8_0_t(174), ufixed8_0_t(25)).get<float>() == 4096, "sg14::safe_multiply test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_add_result_t

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -205,6 +205,7 @@ static_assert(fixed_point_mul_result_t<std::int32_t, -25>::integer_digits == 12,
 
 static_assert(safe_multiply(fixed7_8_t(127), fixed7_8_t(127)).get<int>() == 16129, "sg14::safe_multiply test failed");
 static_assert(safe_multiply<std::uint8_t, -4>(15.9375, 15.9375).get<int>() == 254, "sg14::safe_multiply test failed");
+static_assert(safe_multiply(ufixed4_4_t(0.0625), ufixed4_4_t(0.0625)).get<float>() == 0, "sg14::safe_multiply test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_add_result_t


### PR DESCRIPTION
Incremental improvements to `safe_add` and `safe_multiply`:
* `safe_add` is now variadic
* `safe_multiply` fixes a bug in which all its bits could be shifted out of existence