### PR TITLE
Fp docs

### DIFF
--- a/Docs/Fixed_Point_Library_Proposal.md
+++ b/Docs/Fixed_Point_Library_Proposal.md
@@ -1,0 +1,22 @@
+**Document number**:  
+**Date: 2015-08-12  
+**Project**: Programming Language C++, Library Evolution WG, Evolution WG, SG14  
+**Reply-to**: John McFarlane, john@mcfarlane.name
+
+# Fixed-Point Real Numbers
+
+## I. Motivation
+
+The built-in floating-point types are extremely versatile in their ability to represent real numbers across a very wide range of values. However, the cost of this varsatility is a loss of accuracy and a decrease in accuracy across linear ranges of values.
+
+A common application of floating-point types is to represent ranges of values which follow a linear distribution. Examples include absolute time and spatial measurements as well as unit values in the range [0, 1]. In such cases, having a variable exponent portion in the floating-point value has two disadvantages: 1) it takes precision away from the mantisa and 2) it ensures that the distribution of representable values is clusterd near zero. These characteristics can lead to undesirable behavior when modeling certain real-world phenomena.
+
+In comparison, integral types devote as many bits as possible to precision and their values are distributed entirely linearly. Additionally, both signed and unsigned built-in integral types are far simpler to implement, leading lower hardware requirements. However, the trade off is that this range is entirely dictated by the number of bits and no fractional digits are possible.
+
+
+
+## II. Related work:
+* [N1169](http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1169.pdf) - Extensions to support embedded processors
+* [N3352](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3352.html) - C++ Binary Fixed-Point Arithmetic
+* [fpmath](https://code.google.com/p/fpmath/) - Fixed Point Math Library
+* [boost::fixed_point](http://lists.boost.org/Archives/boost/2012/04/191987.php) - Prototype Boost Library

--- a/Docs/fixed_point.md
+++ b/Docs/fixed_point.md
@@ -1,0 +1,185 @@
+# The `fixed_point` Class Template
+
+[John McFarlane](https://groups.google.com/a/isocpp.org/forum/#!profile/sg14/APn2wQdoie4ys78eOuHNF35KKYtO4LHy0d1z8jGXJ0cr5tzmqGbDbD7BFUzrqWrU7tJiBi_UnRqo)
+
+## 1. Introduction
+
+This document introduces one approach to representing fixed-point real numbers in C++11 using literal class template, `fixed_point`.
+
+### 1.1. Background
+
+It is developed as part of [SG14](https://groups.google.com/a/isocpp.org/forum/#!forum/sg14) which explores the game development and low-latency needs of C++ developers.
+
+### 1.2. Resources
+
+SG14 has  an [unofficial](https://groups.google.com/forum/#!forum/unofficial-real-time-cxx) and an [official](https://groups.google.com/a/isocpp.org/forum/#!forum/sg14) discussion group which contains [a thread](https://groups.google.com/a/isocpp.org/forum/#!topic/sg14/1w5eiJsyT2Q) circulating the original fixed_point idea. A formal [proposal](Fixed_Point_Library_Proposal.md) is also in the works.
+
+There is an [SG14 source code repository](https://github.com/WG21-SG14/SG14) including a header file, [fixed_point.h](https://github.com/WG21-SG14/SG14/blob/master/SG14/fixed_point.h), in which a proof of concept, `sg14::fixed_point`, is actively developed. Accompanying tests can be found in [fixed_point_test.cpp](https://github.com/WG21-SG14/SG14/blob/master/SG14_test/fixed_point_test.cpp).
+
+Anyone with an interest in game and low-latency development in C++ is welcome to contribute to the dicussion and the project.
+
+## 2 Overview
+
+The proof of concept of fixed_point is located in [fixed_point.h](https://github.com/WG21-SG14/SG14/blob/master/SG14/fixed_point.h). For brevity, the project namespace, `sg14` - as well as standard namespace, `std` - is assumed from here on:
+```
+using namespace sg14;
+using namespace std;
+```
+
+The header is intended to be self-contained and should only require a reasonably compliant C++11 compiler. The code is generally tested against Clang 3.6, GCC 4.9 and VC2015.
+
+### 2.1 Basic Usage
+
+Fixed-point real numbers are represented using the following class template:
+```
+fixed_point<typename REPR_TYPE, int EXPONENT>
+```
+where:
+* `REPR_TYPE` is a built-in integral type used to store the value and
+* `EXPONENT` is an integer value governing the number of bits by which the internal value must be shifted in order to represent the real number. 
+
+Note that if `REPR_TYPE` is signed, the `fixed_point` type is also signed.
+
+#### 2.1.1 Converting to `fixed_point` Type
+
+To declare a variable, `pi`, containing a signed real value made up of 3 integer bits and 12 fractional bits:
+```
+auto pi = fixed_point<int16_t, -12>(3.141592654);
+```
+
+You can construct an object from any integral, floating-point or other fixed-point type. Rounding is the same as for float-to-integer conversion. (That is to say, it has not been addressed at all!)
+
+#### 2.1.2 Converting from `fixed_point` to Built-in Types
+
+The `get` function can be used to convert the value back to a built-in type: 
+```
+cout << pi.get<float>();  // output: "3.14163"
+```
+
+#### 2.1.3 Common Aliases
+
+For convenience, you can eschew the `fixed_point<>` notation in favor of pre-defined aliases in a more commonly recognized form. Many sources use I:F notation to describe the number of integral and fractional bits. 
+
+To instantiate a 7:8 value, the following are equivalent:
+```
+auto m = fixed7_8_t(1.23);
+auto m = fixed_point<int16_t, -8>(1.23);
+```
+
+The complete list of aliases is at the bottom of [fixed_point.h](https://github.com/WG21-SG14/SG14/blob/master/SG14/fixed_point.h).
+
+#### 2.1.3 Arithmetic Operations
+
+The intent is for `fixed_point` to behave like a built-in integral or floating-point type. To this end, some basic arithmetic operations have been implemented with more to follow.
+
+Done so far:
+* unary `-`
+* binary `==`, `!=`, `<`, `>`, `<=`, `>=`, `+`, `-`, `*`, `/`, `+=`, `-=`, `*=`, `/=`
+
+#### 2.1.4 Math Functions
+
+So far, `sqrt` and `abs` are available:
+```
+cout << sqrt(abs(fixed3_4_t(-5)));  // output: "2.1875"
+```
+
+### 2.2 Experimental Features
+
+#### 2.2.1 Asking for N Integer Bits
+
+Most likely, you care how many integral bits are stored. You can specialize `fixed_point` this way using `fixed_point_by_integer_digits_t`:
+```
+auto opacity = fixed_point_by_integer_digits_t<uint32_t, 8>(255.999);
+cout << opacity << endl;  // output: "255.999"
+```
+The type of opacity is `fixed_point<uint32_t, -24>`.
+
+#### 2.2.2 `open_unit`, `closed_unit` and `lerp`
+
+A likely application of fixed-point types is in the expression of values in unit intervals. Two partial specializations of `fixed_point`, tentatively named `open_unit<REPR_TYPE>` and `closed_unit<REPR_TYPE>` make it slightly easier to define fixed-point types which have as much precision as possible whilst being able to store values in the range [0,1) and [0,1] respectively.
+
+Accompanying these aliases is the function, `lerp`:
+```
+cout << lerp(ufixed4_4_t(2.5), ufixed4_4_t(7.25), closed_unit<uint8_t>(0.6));  // output: 5.3125
+```
+### 2.3 Advanced Topics
+
+#### 2.3.1 Literal Types and `constexpr`
+
+A quick look at [fixed_point_test.cpp](https://github.com/WG21-SG14/SG14/blob/master/SG14_test/fixed_point_test.cpp) will make it apparent that `fixed_point<>` is a literal type; anything one can do with it at run-time can also be done at compile time. 
+
+Some advantages to this are:
+
+1. Rudimentary automated testing without the need for a framework - simply compile the test file as part of the project. In fact, the limited expressiveness of C++11 constexpr statements ensures that all tests are minimal in scope, in keeping with unit testing practice.
+2. Initialization of instances using literals of built-in type is likely to mean that the object is constructed with virtually no overhead.
+3. Further to this, relatively complex calculations can be performed at compile-time, e.g.:
+   ```
+   enum { TWICE_THE_SQUARE_ROOT_OF_FIFTY = (ufixed16_16_t(2) * sqrt(ufixed16_16_t(50))).get<int>() };
+   cout << TWICE_THE_SQUARE_ROOT_OF_FIFTY;  // output: 14
+   ```
+
+Disadvantages:
+
+1. Especially when limited to C++11, `constexpr` functions are taxing to design as no loops or variables are allowed.
+2. No run-time checks such as `assert` or exceptions are possible, making run-time diagnostics difficult. It may turn out that contracts fix this situation. (TBD)
+
+#### 2.3.1 Promotion
+
+In the context of `fixed_point<>`, promotion refers to explicit convertion of one type to a compatible type of higher capacity. For example:
+```
+auto a = ufixed8_8_t(5.5);
+auto b = promote(a);  // type of b is ufixed16_16_t
+```
+This is akin to casting from `float` to `double`. One can perform precision-critical calculations using the promoted type. Finally, the `demote` function template can be used to convert a value back to the original type. (Although in the above case, `a = b` would do the same job.)
+
+#### 2.3.2 'Safe' Conversion
+
+Usually, it isn't worth the extra complication and performance loss associated with converting to a larger type. In the floating-point case, this is handled automatically by the type's variable exponent. Not so for `fixed_point` types!
+
+Consider this operation:
+```
+cout << ufixed4_4_t(10) * ufixed4_4_t(2);  // output: 4
+```
+Because `ufixed4_4_t` cannot store value 20, there is an overflow. The solution is to use `safe_multiply`:
+```
+cout << safe_multiply(ufixed4_4_t(10), ufixed4_4_t(2));  // output: 20
+```
+This function, and it's partner, `safe_add`, ensure that the result is returned in a type of the same size which is suitable for holding the result. In the above case, `safe_multiply` returns a `ufixed8_0_t`.
+
+With liberal use of the `auto` keyword, much work can be performed this way without the worry of losing siginificant digits:
+```
+template <typename REPR_TYPE, int EXPONENT>
+auto constexpr dot_product(
+	fixed_point<REPR_TYPE, EXPONENT> x1, fixed_point<REPR_TYPE, EXPONENT> y1,
+	fixed_point<REPR_TYPE, EXPONENT> x2, fixed_point<REPR_TYPE, EXPONENT> y2)
+{
+	return safe_add(safe_multiply(x1, x2), safe_multiply(y1, y2));
+}
+
+cout << dot_product(ufixed4_4_t(10), ufixed4_4_t(0), ufixed4_4_t(5), ufixed4_4_t(5));  // output: 50
+```
+
+#### 2.3.3 Extreme Values of Exponent
+
+In the previous example, the function template specialisation of `dot_product` returns a value of type, `fixed_point<uint8_t, 1>`. In other words, it can only express even numbers. It may seem unusual to have a fixed-point type with a negative number of fractional bits, but it is perfectly normal for floating-point types to represent very large numbers this way.
+
+Equally, `fixed_point<uint8_t, -9>` can only represent values in the range [0, 0.5). Again, if that is what is called for, there's no reason not to allow this. Obviously, it makes conversion between different types a little more complicated but otherwise, is simpler that not allowing it.
+
+## Future Work
+
+Some rough notes on where to go next:
+* Default EXPONENT splits bits down the middle, devoting half the bits to fractional.
+* Operators
+  * unary: `!`, `~`
+  * binary: `%`, `<<`, `>>`, `<<=`, `>>=`, `&`, `|`, `^`, `&&`, `||`
+  * pre and post: `++`, `--`
+* many more overloads of cmath functions
+* standard traits and `std::numeric_limits`
+* either remove `open_unit` and `closed_unit` or replace with `open_interval` and `closed_interval`
+* consider complimenting them with types that can store [-1,1] for use with trig functions
+* consider removing `lerp` as it can probably be done as well using arithmetic operations
+* streaming operators are placeholder and fall back on `long double` conversion. 
+* a routine for generating text representations in arbitrary bases.
+* better name for `fixed_point_by_integer_digits_t`
+* 'number of integer digits' might make a better 2nd parameter to `fixed_point<>` itself.
+

--- a/Docs/fixed_point.md
+++ b/Docs/fixed_point.md
@@ -16,7 +16,7 @@ SG14 has  an [unofficial](https://groups.google.com/forum/#!forum/unofficial-rea
 
 There is an [SG14 source code repository](https://github.com/WG21-SG14/SG14) including a header file, [fixed_point.h](https://github.com/WG21-SG14/SG14/blob/master/SG14/fixed_point.h), in which a proof of concept, `sg14::fixed_point`, is actively developed. Accompanying tests can be found in [fixed_point_test.cpp](https://github.com/WG21-SG14/SG14/blob/master/SG14_test/fixed_point_test.cpp).
 
-Anyone with an interest in game and low-latency development in C++ is welcome to contribute to the dicussion and the project.
+Anyone with an interest in game and low-latency development in C++ is welcome to contribute to the discussion and the project.
 
 ## 2 Overview
 
@@ -125,12 +125,12 @@ Disadvantages:
 
 #### 2.3.1 Promotion
 
-In the context of `fixed_point<>`, promotion refers to explicit convertion of one type to a compatible type of higher capacity. For example:
+In the context of `fixed_point<>`, promotion refers to explicit conversion of one type to a compatible type of higher capacity. For example:
 ```
 auto a = ufixed8_8_t(5.5);
 auto b = promote(a);  // type of b is ufixed16_16_t
 ```
-This is akin to casting from `float` to `double`. One can perform precision-critical calculations using the promoted type. Finally, the `demote` function template can be used to convert a value back to the original type. (Although in the above case, `a = b` would do the same job.)
+This is akin to casting from `float` to `double`. One can perform precision-critical calculations using the promoted type. Finally, the `demote` function template can be used to convert a value back to the original type.
 
 #### 2.3.2 'Safe' Conversion
 
@@ -144,9 +144,9 @@ Because `ufixed4_4_t` cannot store value 20, there is an overflow. The solution 
 ```
 cout << safe_multiply(ufixed4_4_t(10), ufixed4_4_t(2));  // output: 20
 ```
-This function, and it's partner, `safe_add`, ensure that the result is returned in a type of the same size which is suitable for holding the result. In the above case, `safe_multiply` returns a `ufixed8_0_t`.
+This function, and its partner, `safe_add`, ensure that the result is returned in a type of the same size which is suitable for holding the result. In the above case, `safe_multiply` returns a `ufixed8_0_t`.
 
-With liberal use of the `auto` keyword, much work can be performed this way without the worry of losing siginificant digits:
+With liberal use of the `auto` keyword, much work can be performed this way without the worry of losing significant digits:
 ```
 template <typename REPR_TYPE, int EXPONENT>
 auto constexpr dot_product(

--- a/Docs/fixed_point.md
+++ b/Docs/fixed_point.md
@@ -165,21 +165,40 @@ In the previous example, the function template specialisation of `dot_product` r
 
 Equally, `fixed_point<uint8_t, -9>` can only represent values in the range [0, 0.5). Again, if that is what is called for, there's no reason not to allow this. Obviously, it makes conversion between different types a little more complicated but otherwise, is simpler that not allowing it.
 
-## Future Work
+## Future API Work
 
-Some rough notes on where to go next:
-* Default EXPONENT splits bits down the middle, devoting half the bits to fractional.
+Some rough notes on where to go next with the design of the API:
+
+### To Discuss
+
+* better name for `safe_` functions
+* 'number of integer digits' might make a better 2nd parameter to `fixed_point<>` itself.
+* should object be default constructed to zero value?
+* should the first template parameter default to int?
+* fixed_point::data is named after the std::vector member function but is this the best choice here?
+* With explicit ctors, operations as simple as ```fixed4_4_t(7) > 5``` do not compile.
+  Is the solution to overload operators, spare the ctors from being explicit, 
+  or live with the verbosity of ```fixed4_4_t(7).get<int>() > 5```?
+* Too many disparate ways to declare specializations of fixed_point? If so, what is a good subset?
+
+### To Do
+
 * Operators
   * unary: `!`, `~`
   * binary: `%`, `<<`, `>>`, `<<=`, `>>=`, `&`, `|`, `^`, `&&`, `||`
   * pre and post: `++`, `--`
 * many more overloads of cmath functions
+* heterogenous safe_add, safe_multiply etc.
+* safe_divide? inverse_t?
 * standard traits and `std::numeric_limits`
 * either remove `open_unit` and `closed_unit` or replace with `open_interval` and `closed_interval`
-* consider complimenting them with types that can store [-1,1] for use with trig functions
 * consider removing `lerp` as it can probably be done as well using arithmetic operations
 * streaming operators are placeholder and fall back on `long double` conversion. 
-* a routine for generating text representations in arbitrary bases.
 * better name for `fixed_point_by_integer_digits_t`
-* 'number of integer digits' might make a better 2nd parameter to `fixed_point<>` itself.
 
+### Possible Additions
+
+* an alias that creates a fixed_point specialization from a maximum, e.g.:
+  * auto n = fixed_point_can_hold_t<int16_t, 4000>();  // type of n is fixed_point<uint16_t, -3>
+* a routine for generating text representations in arbitrary bases.
+* consider complimenting them with types that can store [-1,1] for use with trig functions

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -637,7 +637,7 @@ namespace sg14
 
 	// linear interpolation between two fixed_point values
 	// given floating-point `t` for which result is `from` when t==0 and `to` when t==1
-	template <typename REPR_TYPE, int EXPONENT, typename S, typename>
+	template <typename REPR_TYPE, int EXPONENT, typename S>
 	constexpr fixed_point<REPR_TYPE, EXPONENT> lerp(
 		fixed_point<REPR_TYPE, EXPONENT> from,
 		fixed_point<REPR_TYPE, EXPONENT> to,

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -670,7 +670,7 @@ namespace sg14
 	template <typename REPR_TYPE, int EXPONENT, typename std::enable_if<_impl::is_signed<REPR_TYPE>::value, int>::type dummy = 0>
 	constexpr fixed_point<REPR_TYPE, EXPONENT> abs(fixed_point<REPR_TYPE, EXPONENT> const & x) noexcept
 	{
-		return (x >= fixed_point<REPR_TYPE, EXPONENT>(0)) ? x.data() : - x.data();
+		return (x >= 0) ? x : - x;
 	}
 
 	////////////////////////////////////////////////////////////////////////////////

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -227,6 +227,15 @@ namespace sg14
 		}
 
 		////////////////////////////////////////////////////////////////////////////////
+		// sg14::_impl::default_exponent
+
+		template <typename REPR_TYPE>
+		constexpr int default_exponent() noexcept
+		{
+			return static_cast<signed>(sizeof(REPR_TYPE)) * CHAR_BIT / -2;
+		}
+
+		////////////////////////////////////////////////////////////////////////////////
 		// sg14::_impl::pow2
 
 		// returns given power of 2
@@ -307,7 +316,7 @@ namespace sg14
 	// approximates a real number using a built-in integral type;
 	// somewhat like a floating-point number but - with exponent determined at run-time
 
-	template <typename REPR_TYPE, int EXPONENT = 0>
+	template <typename REPR_TYPE, int EXPONENT = _impl::default_exponent<REPR_TYPE>()>
 	class fixed_point
 	{
 	public:

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -541,7 +541,7 @@ namespace sg14
 	fixed_point_promotion_t<REPR_TYPE, EXPONENT>
 	constexpr promote(fixed_point<REPR_TYPE, EXPONENT> const & from) noexcept
 	{
-		return from;
+		return fixed_point_promotion_t<REPR_TYPE, EXPONENT>(from);
 	}
 
 	////////////////////////////////////////////////////////////////////////////////
@@ -643,7 +643,7 @@ namespace sg14
 		fixed_point<REPR_TYPE, EXPONENT> to,
 		S t)
 	{
-		using closed_unit = closed_unit<REPR_TYPE>;
+		using closed_unit = closed_unit<_impl::make_unsigned<REPR_TYPE>::type>;
 		return lerp<REPR_TYPE, EXPONENT>(from, to, closed_unit(t));
 	}
 
@@ -670,7 +670,7 @@ namespace sg14
 	template <typename REPR_TYPE, int EXPONENT, typename std::enable_if<_impl::is_signed<REPR_TYPE>::value, int>::type dummy = 0>
 	constexpr fixed_point<REPR_TYPE, EXPONENT> abs(fixed_point<REPR_TYPE, EXPONENT> const & x) noexcept
 	{
-		return (x >= 0) ? x : - x;
+		return (x.data() >= 0) ? x : - x;
 	}
 
 	////////////////////////////////////////////////////////////////////////////////

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -652,7 +652,7 @@ namespace sg14
 		fixed_point<REPR_TYPE, EXPONENT> to,
 		S t)
 	{
-		using closed_unit = closed_unit<_impl::make_unsigned<REPR_TYPE>::type>;
+		using closed_unit = closed_unit<typename _impl::make_unsigned<REPR_TYPE>::type>;
 		return lerp<REPR_TYPE, EXPONENT>(from, to, closed_unit(t));
 	}
 

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -636,7 +636,7 @@ namespace sg14
 	// sg14::lerp
 
 	// linear interpolation between two fixed_point values
-	// given floatint-point `t` for which result is `from` when t==0 and `to` when t==1
+	// given floating-point `t` for which result is `from` when t==0 and `to` when t==1
 	template <typename REPR_TYPE, int EXPONENT, typename S, typename>
 	constexpr fixed_point<REPR_TYPE, EXPONENT> lerp(
 		fixed_point<REPR_TYPE, EXPONENT> from,

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -329,31 +329,31 @@ namespace sg14
 
 	private:
 		// constructor taking representation explicitly using operator++(int)-style trick
-		constexpr fixed_point(repr_type repr, int) noexcept
+		explicit constexpr fixed_point(repr_type repr, int) noexcept
 			: _repr(repr)
 		{
 		}
 	public:
 		// default c'tor
-		constexpr fixed_point() noexcept {}
+		explicit constexpr fixed_point() noexcept {}
 
 		// c'tor taking an integer type
 		template <typename S, typename std::enable_if<_impl::is_integral<S>::value, int>::type dummy = 0>
-		constexpr fixed_point(S s) noexcept
+		explicit constexpr fixed_point(S s) noexcept
 			: _repr(integral_to_repr(s))
 		{
 		}
 
 		// c'tor taking a floating-point type
 		template <typename S, typename std::enable_if<std::is_floating_point<S>::value, int>::type dummy = 0>
-		constexpr fixed_point(S s) noexcept
+		explicit constexpr fixed_point(S s) noexcept
 			: _repr(floating_point_to_repr(s))
 		{
 		}
 
 		// c'tor taking a fixed-point type
 		template <typename FROM_REPR_TYPE, int FROM_EXPONENT>
-		constexpr fixed_point(fixed_point<FROM_REPR_TYPE, FROM_EXPONENT> const & rhs) noexcept
+		explicit constexpr fixed_point(fixed_point<FROM_REPR_TYPE, FROM_EXPONENT> const & rhs) noexcept
 			: _repr(_impl::shift_right<(exponent - FROM_EXPONENT), repr_type>(rhs.data()))
 		{
 		}

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -66,6 +66,18 @@ static_assert(_impl::capacity<16>::value == 5, "sg14::_impl::capacity test faile
 // sg14::fixed_point
 
 ////////////////////////////////////////////////////////////////////////////////
+// default second template parameter
+
+static_assert(std::is_same<fixed_point<std::int8_t>, fixed_point<std::int8_t, -4>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::uint8_t>, fixed_point<std::uint8_t, -4>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::int16_t>, fixed_point<std::int16_t, -8>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::uint16_t>, fixed_point<std::uint16_t, -8>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::int32_t>, fixed_point<std::int32_t, -16>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::uint32_t>, fixed_point<std::uint32_t, -16>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::int64_t>, fixed_point<std::int64_t, -32>>::value, "sg14::fixed_point test failed");
+static_assert(std::is_same<fixed_point<std::uint64_t>, fixed_point<std::uint64_t, -32>>::value, "sg14::fixed_point test failed");
+
+////////////////////////////////////////////////////////////////////////////////
 // conversion
 
 // exponent == 0

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -226,10 +226,11 @@ static_assert(safe_add(ufixed4_4_t(15.5), ufixed4_4_t(14.25), ufixed4_4_t(13.5))
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::abs
 
-static_assert(abs(fixed7_0_t(66)).get<int>() == 66, "sg14::sqrt test failed");
-static_assert(abs(fixed7_0_t(-123)).get<int>() == 123, "sg14::sqrt test failed");
-static_assert(abs(fixed63_0_t(9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
-static_assert(abs(fixed63_0_t(-9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::sqrt test failed");
+static_assert(abs(fixed7_0_t(66)).get<int>() == 66, "sg14::abs test failed");
+static_assert(abs(fixed7_0_t(-123)).get<int>() == 123, "sg14::abs test failed");
+static_assert(abs(fixed63_0_t(9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::abs test failed");
+static_assert(abs(fixed63_0_t(-9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::abs test failed");
+static_assert(abs(fixed7_8_t(-5)).get<int>() == 5, "sg14::abs test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::sqrt

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -205,7 +205,7 @@ static_assert(fixed_point_mul_result_t<std::uint8_t, 0>::integer_digits == 16, "
 // sg14::safe_multiply
 
 static_assert(safe_multiply(fixed7_8_t(127), fixed7_8_t(127)).get<int>() == 16129, "sg14::safe_multiply test failed");
-static_assert(safe_multiply<std::uint8_t, -4>(15.9375, 15.9375).get<int>() == 254, "sg14::safe_multiply test failed");
+static_assert(safe_multiply(ufixed4_4_t(15.9375), ufixed4_4_t(15.9375)).get<int>() == 254, "sg14::safe_multiply test failed");
 static_assert(safe_multiply(ufixed4_4_t(0.0625), ufixed4_4_t(0.0625)).get<float>() == 0, "sg14::safe_multiply test failed");
 static_assert(safe_multiply(ufixed8_0_t(1), ufixed8_0_t(1)).get<float>() == 0, "sg14::safe_multiply test failed");
 static_assert(safe_multiply(ufixed8_0_t(174), ufixed8_0_t(25)).get<float>() == 4096, "sg14::safe_multiply test failed");
@@ -220,7 +220,6 @@ static_assert(fixed_point_add_result_t<std::int32_t, -25, 4>::integer_digits == 
 // sg14::safe_add
 
 static_assert(safe_add(fixed_point<std::uint8_t, -1>(127), fixed_point<std::uint8_t, -1>(127)).get<int>() == 254, "sg14::safe_add test failed");
-static_assert(safe_add<std::uint8_t, -4>(15, 13).get<int>() == 28, "sg14::safe_add test failed");
 static_assert(safe_add(ufixed4_4_t(15.5), ufixed4_4_t(14.25), ufixed4_4_t(13.5)).get<float>() == 43.25, "sg14::safe_add test failed");
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/VS2015/SG14/SG14.sln
+++ b/VS2015/SG14/SG14.sln
@@ -1,11 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SG14", "SG14\SG14.vcxproj", "{71063685-C50D-4C69-AE56-7184DE4FECCB}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SG14_test", "SG14_test\SG14_test.vcxproj", "{57589953-7A78-4903-A70C-EB7819E02A28}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{32AC75D4-40B1-4373-94EF-DB403A517843}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\Docs\fixed_point.md = ..\..\Docs\fixed_point.md
+		..\..\Docs\Fixed_Point_Library_Proposal.md = ..\..\Docs\Fixed_Point_Library_Proposal.md
+		..\..\Docs\Proposals\RollingQueueProposal.pdf = ..\..\Docs\Proposals\RollingQueueProposal.pdf
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/VS2015/SG14/SG14/SG14.vcxproj
+++ b/VS2015/SG14/SG14/SG14.vcxproj
@@ -14,6 +14,10 @@
     <ClInclude Include="..\..\..\SG14\fixed_point.h" />
     <ClInclude Include="..\..\..\SG14\rolling_queue.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\Docs\Fixed_Point_Library_Proposal.md" />
+    <None Include="..\..\..\Docs\fixed_point.md" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{71063685-C50D-4C69-AE56-7184DE4FECCB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/VS2015/SG14/SG14/SG14.vcxproj.filters
+++ b/VS2015/SG14/SG14/SG14.vcxproj.filters
@@ -4,4 +4,8 @@
     <ClInclude Include="..\..\..\SG14\rolling_queue.h" />
     <ClInclude Include="..\..\..\SG14\fixed_point.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\Docs\fixed_point.md" />
+    <None Include="..\..\..\Docs\Fixed_Point_Library_Proposal.md" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds a draft of a markdown document, fixed_point.md, to the Docs folder. Also, numerous changes including addressing a test failure introduced in the previous merge. 

code changes:
* ctors are now marked `explicit`;
* exponent parameter of `fixed_point` template defaults to even divide between integer and fractional bits;
* fixes compile-time bug in `abs`.