### PR TITLE
Fp ease of use

### DIFF
--- a/Docs/fixed_point.md
+++ b/Docs/fixed_point.md
@@ -56,7 +56,21 @@ Object can be explicitly cast back to built-in types:
 cout << static_cast<float>(pi);  // output: "3.14163"
 ```
 
-#### 2.1.3 Common Aliases
+#### 2.1.3 Made-To-Measure Types
+
+Most likely, you care how many integral bits are stored. There are two ways of creating a fixed_point type from this value:
+
+You can simply specify the amounts of everything - including sign bit:
+```
+auto opacity = make_fixed<8, 8, false>(255.999);  // 8:8 unsigned value
+```
+
+Alternatively you can specify the underlying type and the desired number of integer bits:
+```
+auto degrees = make_fixed_from_repr<int32_t, 9>(360);  // 9:22 signed value
+```
+
+#### 2.1.4 Common Aliases
 
 For convenience, you can eschew the `fixed_point<>` notation in favor of pre-defined aliases in a more commonly recognized form. Many sources use I:F notation to describe the number of integral and fractional bits. 
 
@@ -68,7 +82,7 @@ auto m = fixed_point<int16_t, -8>(1.23);
 
 The complete list of aliases is at the bottom of [fixed_point.h](https://github.com/WG21-SG14/SG14/blob/master/SG14/fixed_point.h).
 
-#### 2.1.3 Arithmetic Operations
+#### 2.1.5 Arithmetic Operations
 
 The intent is for `fixed_point` to behave like a built-in integral or floating-point type. To this end, some basic arithmetic operations have been implemented with more to follow.
 
@@ -76,25 +90,14 @@ Done so far:
 * unary `-`
 * binary `==`, `!=`, `<`, `>`, `<=`, `>=`, `+`, `-`, `*`, `/`, `+=`, `-=`, `*=`, `/=`
 
-#### 2.1.4 Math Functions
+#### 2.1.6 Math Functions
 
 So far, `sqrt` and `abs` are available:
 ```
 cout << sqrt(abs(fixed3_4_t(-5)));  // output: "2.1875"
 ```
 
-### 2.2 Experimental Features
-
-#### 2.2.1 Asking for N Integer Bits
-
-Most likely, you care how many integral bits are stored. You can specialize `fixed_point` this way using `fixed_point_by_integer_digits_t`:
-```
-auto opacity = fixed_point_by_integer_digits_t<uint32_t, 8>(255.999);
-cout << opacity << endl;  // output: "255.999"
-```
-The type of opacity is `fixed_point<uint32_t, -24>`.
-
-#### 2.2.2 `open_unit`, `closed_unit` and `lerp`
+#### 2.1.7 `open_unit`, `closed_unit` and `lerp`
 
 A likely application of fixed-point types is in the expression of values in unit intervals. Two partial specializations of `fixed_point`, tentatively named `open_unit<REPR_TYPE>` and `closed_unit<REPR_TYPE>` make it slightly easier to define fixed-point types which have as much precision as possible whilst being able to store values in the range [0,1) and [0,1] respectively.
 
@@ -102,9 +105,9 @@ Accompanying these aliases is the function, `lerp`:
 ```
 cout << lerp(ufixed4_4_t(2.5), ufixed4_4_t(7.25), closed_unit<uint8_t>(0.6));  // output: 5.3125
 ```
-### 2.3 Advanced Topics
+### 2.2 Advanced Topics
 
-#### 2.3.1 Literal Types and `constexpr`
+#### 2.2.1 Literal Types and `constexpr`
 
 A quick look at [fixed_point_test.cpp](https://github.com/WG21-SG14/SG14/blob/master/SG14_test/fixed_point_test.cpp) will make it apparent that `fixed_point<>` is a literal type; anything one can do with it at run-time can also be done at compile time. 
 
@@ -123,7 +126,7 @@ Disadvantages:
 1. Especially when limited to C++11, `constexpr` functions are taxing to design as no loops or variables are allowed.
 2. No run-time checks such as `assert` or exceptions are possible, making run-time diagnostics difficult. It may turn out that contracts fix this situation. (TBD)
 
-#### 2.3.1 Promotion
+#### 2.2.2 Promotion
 
 In the context of `fixed_point<>`, promotion refers to explicit conversion of one type to a compatible type of higher capacity. For example:
 ```
@@ -132,7 +135,7 @@ auto b = promote(a);  // type of b is ufixed16_16_t
 ```
 This is akin to casting from `float` to `double`. One can perform precision-critical calculations using the promoted type. Finally, the `demote` function template can be used to convert a value back to the original type.
 
-#### 2.3.2 'Safe' Conversion
+#### 2.2.3 'Safe' Conversion
 
 Usually, it isn't worth the extra complication and performance loss associated with converting to a larger type. In the floating-point case, this is handled automatically by the type's variable exponent. Not so for `fixed_point` types!
 
@@ -159,26 +162,26 @@ auto constexpr dot_product(
 cout << dot_product(ufixed4_4_t(10), ufixed4_4_t(0), ufixed4_4_t(5), ufixed4_4_t(5));  // output: 50
 ```
 
-#### 2.3.3 Extreme Values of Exponent
+#### 2.2.4 Extreme Values of Exponent
 
 In the previous example, the function template specialisation of `dot_product` returns a value of type, `fixed_point<uint8_t, 1>`. In other words, it can only express even numbers. It may seem unusual to have a fixed-point type with a negative number of fractional bits, but it is perfectly normal for floating-point types to represent very large numbers this way.
 
 Equally, `fixed_point<uint8_t, -9>` can only represent values in the range [0, 0.5). Again, if that is what is called for, there's no reason not to allow this. Obviously, it makes conversion between different types a little more complicated but otherwise, is simpler that not allowing it.
 
-## Future API Work
+## 3 Future API Work
 
 Some rough notes on where to go next with the design of the API:
 
-### To Discuss
+### 3.1 To Discuss
 
 * better name for `safe_` functions
-* 'number of integer digits' might make a better 2nd parameter to `fixed_point<>` itself.
+* 'number of integer digits' might make a better 2nd parameter to `fixed_point<>`.
 * should object be default constructed to zero value?
 * should the first template parameter default to int?
 * fixed_point::data is named after the std::vector member function but is this the best choice here?
 * Too many disparate ways to declare specializations of fixed_point? If so, what is a good subset?
 
-### To Do
+### 3.2 To Do
 
 * Operators
   * unary: `!`, `~`

--- a/Docs/fixed_point.md
+++ b/Docs/fixed_point.md
@@ -51,9 +51,9 @@ You can construct an object from any integral, floating-point or other fixed-poi
 
 #### 2.1.2 Converting from `fixed_point` to Built-in Types
 
-The `get` function can be used to convert the value back to a built-in type: 
+Object can be explicitly cast back to built-in types:
 ```
-cout << pi.get<float>();  // output: "3.14163"
+cout << static_cast<float>(pi);  // output: "3.14163"
 ```
 
 #### 2.1.3 Common Aliases
@@ -114,7 +114,7 @@ Some advantages to this are:
 2. Initialization of instances using literals of built-in type is likely to mean that the object is constructed with virtually no overhead.
 3. Further to this, relatively complex calculations can be performed at compile-time, e.g.:
    ```
-   enum { TWICE_THE_SQUARE_ROOT_OF_FIFTY = (ufixed16_16_t(2) * sqrt(ufixed16_16_t(50))).get<int>() };
+   enum { TWICE_THE_SQUARE_ROOT_OF_FIFTY = ufixed16_16_t(2) * sqrt(ufixed16_16_t(50)) };
    cout << TWICE_THE_SQUARE_ROOT_OF_FIFTY;  // output: 14
    ```
 
@@ -176,9 +176,6 @@ Some rough notes on where to go next with the design of the API:
 * should object be default constructed to zero value?
 * should the first template parameter default to int?
 * fixed_point::data is named after the std::vector member function but is this the best choice here?
-* With explicit ctors, operations as simple as ```fixed4_4_t(7) > 5``` do not compile.
-  Is the solution to overload operators, spare the ctors from being explicit, 
-  or live with the verbosity of ```fixed4_4_t(7).get<int>() > 5```?
 * Too many disparate ways to declare specializations of fixed_point? If so, what is a good subset?
 
 ### To Do

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -369,14 +369,14 @@ namespace sg14
 
 		// returns value represented as a floating-point
 		template <typename S, typename std::enable_if<_impl::is_integral<S>::value, int>::type dummy = 0>
-		constexpr S get() const noexcept
+		explicit constexpr operator S() const noexcept
 		{
 			return repr_to_integral<S>(_repr);
 		}
 
 		// returns value represented as integral
 		template <typename S, typename std::enable_if<std::is_floating_point<S>::value, int>::type dummy = 0>
-		constexpr S get() const noexcept
+		explicit constexpr operator S() const noexcept
 		{
 			return repr_to_floating_point<S>(_repr);
 		}

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -20,6 +20,15 @@ namespace sg14
 	namespace _impl
 	{
 		////////////////////////////////////////////////////////////////////////////////
+		// num_bits
+
+		template <typename T>
+		constexpr int num_bits()
+		{
+			return sizeof(T) * CHAR_BIT;
+		}
+
+		////////////////////////////////////////////////////////////////////////////////
 		// sg14::_impl::get_int_t
 
 		template <bool SIGNED, int NUM_BYTES>
@@ -232,7 +241,7 @@ namespace sg14
 		template <typename REPR_TYPE>
 		constexpr int default_exponent() noexcept
 		{
-			return static_cast<signed>(sizeof(REPR_TYPE)) * CHAR_BIT / -2;
+			return num_bits<REPR_TYPE>() / -2;
 		}
 
 		////////////////////////////////////////////////////////////////////////////////
@@ -285,7 +294,7 @@ namespace sg14
 		template <typename REPR_TYPE>
 		constexpr REPR_TYPE sqrt_bit(
 			REPR_TYPE n,
-			REPR_TYPE bit = REPR_TYPE(1) << (sizeof(REPR_TYPE) * CHAR_BIT - 2)) noexcept
+			REPR_TYPE bit = REPR_TYPE(1) << (num_bits<REPR_TYPE>() - 2)) noexcept
 		{
 			return (bit > n) ? sqrt_bit<REPR_TYPE>(n, bit >> 2) : bit;
 		}
@@ -329,7 +338,7 @@ namespace sg14
 		// constants
 
 		constexpr static int exponent = EXPONENT;
-		constexpr static int digits = sizeof(repr_type) * CHAR_BIT - _impl::is_signed<repr_type>::value;
+		constexpr static int digits = _impl::num_bits<REPR_TYPE>() - _impl::is_signed<repr_type>::value;
 		constexpr static int integer_digits = digits + exponent;
 		constexpr static int fractional_digits = digits - integer_digits;
 
@@ -526,7 +535,7 @@ namespace sg14
 	// fixed-point type capable of storing values in the range [0, 1);
 	// a bit more precise than closed_unit
 	template <typename REPR_TYPE>
-	using open_unit = fixed_point<REPR_TYPE, - static_cast<int>(sizeof(REPR_TYPE)) * CHAR_BIT>;
+	using open_unit = fixed_point<REPR_TYPE, -_impl::num_bits<REPR_TYPE>()>;
 
 	// fixed-point type capable of storing values in the range [0, 1];
 	// actually storing values in the range [0, 2);
@@ -534,7 +543,7 @@ namespace sg14
 	template <typename REPR_TYPE>
 	using closed_unit = fixed_point<
 		typename std::enable_if<_impl::is_unsigned<REPR_TYPE>::value, REPR_TYPE>::type,
-		1 - static_cast<int>(sizeof(REPR_TYPE)) * CHAR_BIT>;
+		1 - _impl::num_bits<REPR_TYPE>()>;
 
 	////////////////////////////////////////////////////////////////////////////////
 	// sg14::fixed_point_promotion_t / promote

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -289,6 +289,15 @@ namespace sg14
 		};
 
 		////////////////////////////////////////////////////////////////////////////////
+		// _impl::necessary_repr_t
+
+		// given a required number of bits a type should have and whether it is signed,
+		// provides a built-in integral type with necessary capacity
+		template <unsigned REQUIRED_BITS, bool IS_SIGNED>
+		using necessary_repr_t 
+			= typename get_int<IS_SIGNED, 1 << (capacity<((REQUIRED_BITS + 7) / 8) - 1>::value)>::type;
+
+		////////////////////////////////////////////////////////////////////////////////
 		// sg14::sqrt helper functions
 
 		template <typename REPR_TYPE>
@@ -528,6 +537,19 @@ namespace sg14
 
 		repr_type _repr = 0;
 	};
+
+	////////////////////////////////////////////////////////////////////////////////
+	// sg14::make_fixed
+
+	// given the desired number of integer and fractional digits,
+	// generates a fixed_point type such that:
+	//   fixed_point<>::integer_digits == INTEGER_DIGITS,
+	// and
+	//   fixed_point<>::fractional_digits >= FRACTIONAL_DIGITS,
+	template <unsigned INTEGER_DIGITS, unsigned FRACTIONAL_DIGITS, bool IS_SIGNED = true>
+	using make_fixed = fixed_point<
+		typename _impl::necessary_repr_t<INTEGER_DIGITS + FRACTIONAL_DIGITS + IS_SIGNED, IS_SIGNED>,
+		(INTEGER_DIGITS + IS_SIGNED) - _impl::num_bits<typename _impl::necessary_repr_t<INTEGER_DIGITS + FRACTIONAL_DIGITS + IS_SIGNED, IS_SIGNED>>()>;
 
 	////////////////////////////////////////////////////////////////////////////////
 	// sg14::open_unit and sg14::closed_unit partial specializations of fixed_point

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -549,7 +549,7 @@ namespace sg14
 	template <unsigned INTEGER_DIGITS, unsigned FRACTIONAL_DIGITS, bool IS_SIGNED = true>
 	using make_fixed = fixed_point<
 		typename _impl::necessary_repr_t<INTEGER_DIGITS + FRACTIONAL_DIGITS + IS_SIGNED, IS_SIGNED>,
-		(INTEGER_DIGITS + IS_SIGNED) - _impl::num_bits<typename _impl::necessary_repr_t<INTEGER_DIGITS + FRACTIONAL_DIGITS + IS_SIGNED, IS_SIGNED>>()>;
+		(signed)(INTEGER_DIGITS + IS_SIGNED) - _impl::num_bits<typename _impl::necessary_repr_t<INTEGER_DIGITS + FRACTIONAL_DIGITS + IS_SIGNED, IS_SIGNED>>()>;
 
 	////////////////////////////////////////////////////////////////////////////////
 	// sg14::make_fixed_from_repr

--- a/SG14/fixed_point.h
+++ b/SG14/fixed_point.h
@@ -552,6 +552,16 @@ namespace sg14
 		(INTEGER_DIGITS + IS_SIGNED) - _impl::num_bits<typename _impl::necessary_repr_t<INTEGER_DIGITS + FRACTIONAL_DIGITS + IS_SIGNED, IS_SIGNED>>()>;
 
 	////////////////////////////////////////////////////////////////////////////////
+	// sg14::make_fixed_from_repr
+
+	// yields a float_point with EXPONENT calculated such that 
+	// fixed_point<REPR_TYPE, EXPONENT>::integer_bits == INTEGER_BITS
+	template <typename REPR_TYPE, int INTEGER_BITS>
+	using make_fixed_from_repr = fixed_point<
+		REPR_TYPE,
+		INTEGER_BITS + _impl::is_signed<REPR_TYPE>::value - (signed)sizeof(REPR_TYPE) * CHAR_BIT>;
+
+	////////////////////////////////////////////////////////////////////////////////
 	// sg14::open_unit and sg14::closed_unit partial specializations of fixed_point
 
 	// fixed-point type capable of storing values in the range [0, 1);
@@ -602,16 +612,6 @@ namespace sg14
 	}
 
 	////////////////////////////////////////////////////////////////////////////////
-	// sg14::fixed_point_by_integer_digits_t
-
-	// yields a float_point with EXPONENT calculated such that 
-	// fixed_point<REPR_TYPE, EXPONENT>::integer_bits == INTEGER_BITS
-	template <typename REPR_TYPE, int INTEGER_BITS>
-	using fixed_point_by_integer_digits_t = fixed_point<
-		REPR_TYPE, 
-		INTEGER_BITS + _impl::is_signed<REPR_TYPE>::value - (signed)sizeof(REPR_TYPE) * CHAR_BIT>;
-
-	////////////////////////////////////////////////////////////////////////////////
 	// sg14::fixed_point_mul_result_t / safe_multiply
 	//
 	// TODO: accept factors of heterogeneous specialization, e.g.:
@@ -620,7 +620,7 @@ namespace sg14
 	// yields specialization of fixed_point with integral bits necessary to store 
 	// result of a multiply between values of fixed_point<REPR_TYPE, EXPONENT>
 	template <typename REPR_TYPE, int EXPONENT>
-	using fixed_point_mul_result_t = fixed_point_by_integer_digits_t<
+	using fixed_point_mul_result_t = make_fixed_from_repr<
 		REPR_TYPE,
 		fixed_point<REPR_TYPE, EXPONENT>::integer_digits * 2>;
 
@@ -643,7 +643,7 @@ namespace sg14
 	// yields specialization of fixed_point with integral bits necessary to store 
 	// result of an addition between N values of fixed_point<REPR_TYPE, EXPONENT>
 	template <typename REPR_TYPE, int EXPONENT, unsigned N = 2>
-	using fixed_point_add_result_t = fixed_point_by_integer_digits_t<
+	using fixed_point_add_result_t = make_fixed_from_repr<
 		REPR_TYPE,
 		fixed_point<REPR_TYPE, EXPONENT>::integer_digits + _impl::capacity<N - 1>::value>;
 

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -231,10 +231,10 @@ static_assert(std::is_same<fixed_point<std::int8_t, -4>, fixed_point_demotion_t<
 static_assert(std::is_same<fixed_point<std::uint32_t, 44>, fixed_point_demotion_t<std::uint64_t, 88>>::value, "sg14::promotion test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
-// sg14::fixed_point_by_integer_digits_t
+// sg14::make_fixed_from_repr
 
-static_assert(fixed_point_by_integer_digits_t<std::uint8_t, 8>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
-static_assert(fixed_point_by_integer_digits_t<std::int32_t, 27>::integer_digits == 27, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(make_fixed_from_repr<std::uint8_t, 8>::integer_digits == 8, "sg14::make_fixed_from_repr test failed");
+static_assert(make_fixed_from_repr<std::int32_t, 27>::integer_digits == 27, "sg14::make_fixed_from_repr test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_mul_result_t

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -239,9 +239,9 @@ static_assert(fixed_point_by_integer_digits_t<std::int32_t, 27>::integer_digits 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_mul_result_t
 
-static_assert(fixed_point_mul_result_t<std::uint8_t, -4>::integer_digits == 8, "sg14::fixed_point_by_integer_digits_t test failed");
-static_assert(fixed_point_mul_result_t<std::int32_t, -25>::integer_digits == 12, "sg14::fixed_point_by_integer_digits_t test failed");
-static_assert(fixed_point_mul_result_t<std::uint8_t, 0>::integer_digits == 16, "sg14::fixed_point_by_integer_digits_t test failed");
+static_assert(fixed_point_mul_result_t<std::uint8_t, -4>::integer_digits == 8, "sg14::fixed_point_mul_result_t test failed");
+static_assert(fixed_point_mul_result_t<std::int32_t, -25>::integer_digits == 12, "sg14::fixed_point_mul_result_t test failed");
+static_assert(fixed_point_mul_result_t<std::uint8_t, 0>::integer_digits == 16, "sg14::fixed_point_mul_result_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::safe_multiply

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -85,10 +85,10 @@ static_assert(std::is_same<_impl::necessary_repr_t<64, false>, std::uint64_t>::v
 static_assert(std::is_same<_impl::necessary_repr_t<64, true>, std::int64_t>::value, "sg14::_impl::necessary_repr_t");
 
 #if defined(_SG14_FIXED_POINT_128)
-static_assert(std::is_same<_impl::necessary_repr_t<65, false>, std::uint128_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<65, true>, std::int64_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<128, false>, std::uint64_t>::value, "sg14::_impl::necessary_repr_t");
-static_assert(std::is_same<_impl::necessary_repr_t<128, true>, std::int64_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<65, false>, unsigned __int128>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<65, true>, __int128>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<128, false>, unsigned __int128>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<128, true>, __int128>::value, "sg14::_impl::necessary_repr_t");
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -81,111 +81,111 @@ static_assert(std::is_same<fixed_point<std::uint64_t>, fixed_point<std::uint64_t
 // conversion
 
 // exponent == 0
-static_assert(ufixed8_0_t(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
-static_assert(ufixed16_0_t(12.34f).get<double>() == 12.f, "sg14::fixed_point test failed");
-static_assert(ufixed32_0_t(12.34f).get<long double>() == 12.f, "sg14::fixed_point test failed");
-static_assert(ufixed64_0_t(12.34f).get<float>() == 12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(ufixed8_0_t(12.34f)) == 12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(ufixed16_0_t(12.34f)) == 12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<long double>(ufixed32_0_t(12.34f)) == 12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(ufixed64_0_t(12.34f)) == 12.f, "sg14::fixed_point test failed");
 
-static_assert(fixed7_0_t(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
-static_assert(fixed15_0_t(-12.34f).get<long double>() == -12.f, "sg14::fixed_point test failed");
-static_assert(fixed31_0_t(-12.34f).get<float>() == -12.f, "sg14::fixed_point test failed");
-static_assert(fixed63_0_t(-12.34f).get<double>() == -12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(fixed7_0_t(-12.34f)) == -12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<long double>(fixed15_0_t(-12.34f)) == -12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed31_0_t(-12.34f)) == -12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(fixed63_0_t(-12.34f)) == -12.f, "sg14::fixed_point test failed");
 
 // exponent = -1
-static_assert(fixed_point<std::uint8_t, -1>(127.5).get<float>() == 127.5, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::uint8_t, -1>(127.5)) == 127.5, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::int8_t, -1>(63.5).get<float>() == 63.5, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, -1>(-63.5).get<float>() == -63.5, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::int8_t, -1>(63.5)) == 63.5, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::int8_t, -1>(-63.5)) == -63.5, "sg14::fixed_point test failed");
 
 // exponent == -7
-static_assert(fixed_point<std::uint8_t, -7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint16_t, -8>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint32_t, -7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint64_t, -7>(232.125f).get<float>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::uint8_t, -7>(.125f)) == .125f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::uint16_t, -8>(232.125f)) == 232.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::uint32_t, -7>(232.125f)) == 232.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::uint64_t, -7>(232.125f)) == 232.125f, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::int8_t, -7>(.125f).get<float>() == .125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int16_t, -7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int32_t, -7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int64_t, -7>(123.125f).get<float>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::int8_t, -7>(.125f)) == .125f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::int16_t, -7>(123.125f)) == 123.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::int32_t, -7>(123.125f)) == 123.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::int64_t, -7>(123.125f)) == 123.125f, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::uint8_t, -7>(.125f).get<double>() == .125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint16_t, -8>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint32_t, -7>(232.125f).get<double>() == 232.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint64_t, -7>(232.125f).get<long double>() == 232.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(fixed_point<std::uint8_t, -7>(.125f)) == .125f, "sg14::fixed_point test failed");
+static_assert(static_cast<long double>(fixed_point<std::uint16_t, -8>(232.125f)) == 232.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(fixed_point<std::uint32_t, -7>(232.125f)) == 232.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<long double>(fixed_point<std::uint64_t, -7>(232.125f)) == 232.125f, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::int8_t, -7>(1).get<long double>() != 1.f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, -7>(.5).get<float>() == .5f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, -7>(.125f).get<long double>() == .125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int16_t, -7>(123.125f).get<int>() == 123, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int32_t, -7>(123.125f).get<long double>() == 123.125f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int64_t, -7>(123.125l).get<float>() == 123.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<long double>(fixed_point<std::int8_t, -7>(1)) != 1.f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::int8_t, -7>(.5)) == .5f, "sg14::fixed_point test failed");
+static_assert(static_cast<long double>(fixed_point<std::int8_t, -7>(.125f)) == .125f, "sg14::fixed_point test failed");
+static_assert(static_cast<int>(fixed_point<std::int16_t, -7>(123.125f)) == 123, "sg14::fixed_point test failed");
+static_assert(static_cast<long double>(fixed_point<std::int32_t, -7>(123.125f)) == 123.125f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::int64_t, -7>(123.125l)) == 123.125f, "sg14::fixed_point test failed");
 
 // exponent == 16
-static_assert(fixed_point<std::uint8_t, 16>(65536).get<float>() == 65536.f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint16_t, 16>(6553.).get<int>() == 0, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint32_t, 16>(4294967296l).get<double>() == 4294967296.f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint64_t, 16>(1125895611875328l).get<double>() == 1125895611875328l, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::uint8_t, 16>(65536)) == 65536.f, "sg14::fixed_point test failed");
+static_assert(static_cast<int>(fixed_point<std::uint16_t, 16>(6553.)) == 0, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(fixed_point<std::uint32_t, 16>(4294967296l)) == 4294967296.f, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(fixed_point<std::uint64_t, 16>(1125895611875328l)) == 1125895611875328l, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::int8_t, 16>(-65536).get<float>() == -65536.f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int16_t, 16>(-6553.).get<int>() == 0, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int32_t, 16>(-4294967296l).get<double>() == -4294967296.f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int64_t, 16>(-1125895611875328l).get<double>() == -1125895611875328l, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::int8_t, 16>(-65536)) == -65536.f, "sg14::fixed_point test failed");
+static_assert(static_cast<int>(fixed_point<std::int16_t, 16>(-6553.)) == 0, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(fixed_point<std::int32_t, 16>(-4294967296l)) == -4294967296.f, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(fixed_point<std::int64_t, 16>(-1125895611875328l)) == -1125895611875328l, "sg14::fixed_point test failed");
 
 // exponent = 1
-static_assert(fixed_point<std::uint8_t, 1>(510).get<int>() == 510, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint8_t, 1>(511).get<int>() == 510, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, 1>(123.5).get<float>() == 122, "sg14::fixed_point test failed");
+static_assert(static_cast<int>(fixed_point<std::uint8_t, 1>(510)) == 510, "sg14::fixed_point test failed");
+static_assert(static_cast<int>(fixed_point<std::uint8_t, 1>(511)) == 510, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::int8_t, 1>(123.5)) == 122, "sg14::fixed_point test failed");
 
-static_assert(fixed_point<std::int8_t, 1>(255).get<int>() == 254, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, 1>(254).get<int>() == 254, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::int8_t, 1>(-5).get<int>() == -6, "sg14::fixed_point test failed");
+static_assert(static_cast<int>(fixed_point<std::int8_t, 1>(255)) == 254, "sg14::fixed_point test failed");
+static_assert(static_cast<int>(fixed_point<std::int8_t, 1>(254)) == 254, "sg14::fixed_point test failed");
+static_assert(static_cast<int>(fixed_point<std::int8_t, 1>(-5)) == -6, "sg14::fixed_point test failed");
 
 // conversion between fixed_point specializations
-static_assert(ufixed4_4_t(fixed7_8_t(1.5)).get<float>() == 1.5, "sg14::fixed_point test failed");
-static_assert(ufixed8_8_t(fixed3_4_t(3.25)).get<float>() == 3.25, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint8_t, 4>(fixed_point<std::int16_t, -4>(768)).get<int>() == 768, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint64_t, -48>(fixed_point<std::uint32_t, -24>(3.141592654)).get<float>() > 3.1415923f, "sg14::fixed_point test failed");
-static_assert(fixed_point<std::uint64_t, -48>(fixed_point<std::uint32_t, -24>(3.141592654)).get<float>() < 3.1415927f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(ufixed4_4_t(fixed7_8_t(1.5))) == 1.5, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(ufixed8_8_t(fixed3_4_t(3.25))) == 3.25, "sg14::fixed_point test failed");
+static_assert(static_cast<int>(fixed_point<std::uint8_t, 4>(fixed_point<std::int16_t, -4>(768))) == 768, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::uint64_t, -48>(fixed_point<std::uint32_t, -24>(3.141592654))) > 3.1415923f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(fixed_point<std::uint64_t, -48>(fixed_point<std::uint32_t, -24>(3.141592654))) < 3.1415927f, "sg14::fixed_point test failed");
 
 // closed_unit
-static_assert(closed_unit<std::uint8_t>(.5).get<double>() == .5, "sg14::closed_unit test failed");
-static_assert(closed_unit<std::uint16_t>(.125f).get<float>() == .125f, "sg14::closed_unit test failed");
-static_assert(closed_unit<std::uint16_t>(.640625l).get<float>() == .640625, "sg14::closed_unit test failed");
-static_assert(closed_unit<std::uint16_t>(1.640625).get<float>() == 1.640625f, "sg14::closed_unit test failed");
-static_assert(closed_unit<std::uint16_t>(1u).get<std::uint64_t>() == 1, "sg14::closed_unit test failed");
-static_assert(closed_unit<std::uint16_t>(2).get<float>() != 2, "sg14::closed_unit test failed");	// out-of-range test
+static_assert(static_cast<double>(closed_unit<std::uint8_t>(.5)) == .5, "sg14::closed_unit test failed");
+static_assert(static_cast<float>(closed_unit<std::uint16_t>(.125f)) == .125f, "sg14::closed_unit test failed");
+static_assert(static_cast<float>(closed_unit<std::uint16_t>(.640625l)) == .640625, "sg14::closed_unit test failed");
+static_assert(static_cast<float>(closed_unit<std::uint16_t>(1.640625)) == 1.640625f, "sg14::closed_unit test failed");
+static_assert(static_cast<std::uint64_t>(closed_unit<std::uint16_t>(1u)) == 1, "sg14::closed_unit test failed");
+static_assert(static_cast<float>(closed_unit<std::uint16_t>(2)) != 2, "sg14::closed_unit test failed");	// out-of-range test
 
 // open_unit
-static_assert(open_unit<std::uint8_t>(.5).get<double>() == .5, "sg14::closed_unit test failed");
-static_assert(open_unit<std::uint16_t>(.125f).get<float>() == .125f, "sg14::closed_unit test failed");
-static_assert(open_unit<std::uint16_t>(.640625l).get<float>() == .640625, "sg14::closed_unit test failed");
-static_assert(open_unit<std::uint16_t>(1).get<float>() == 0, "sg14::closed_unit test failed");	// dropped bit
+static_assert(static_cast<double>(open_unit<std::uint8_t>(.5)) == .5, "sg14::closed_unit test failed");
+static_assert(static_cast<float>(open_unit<std::uint16_t>(.125f)) == .125f, "sg14::closed_unit test failed");
+static_assert(static_cast<float>(open_unit<std::uint16_t>(.640625l)) == .640625, "sg14::closed_unit test failed");
+static_assert(static_cast<float>(open_unit<std::uint16_t>(1)) == 0, "sg14::closed_unit test failed");	// dropped bit
 
 ////////////////////////////////////////////////////////////////////////////////
 // arithmetic
 
 // addition
-static_assert((fixed31_0_t(123) + fixed31_0_t(123)).get<int>() == 246, "sg14::fixed_point test failed");
-static_assert((fixed15_16_t(123.125) + fixed15_16_t(123.75)).get<float>() == 246.875, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((fixed31_0_t(123) + fixed31_0_t(123))) == 246, "sg14::fixed_point test failed");
+static_assert(static_cast<float>((fixed15_16_t(123.125) + fixed15_16_t(123.75))) == 246.875, "sg14::fixed_point test failed");
 
 // subtraction
-static_assert((fixed31_0_t(999) - fixed31_0_t(369)).get<int>() == 630, "sg14::fixed_point test failed");
-static_assert((fixed15_16_t(246.875) - fixed15_16_t(123.75)).get<float>() == 123.125, "sg14::fixed_point test failed");
-static_assert((fixed_point<std::int16_t, -4>(123.125) - fixed_point<std::int16_t, -4>(246.875)).get<float>() == -123.75, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((fixed31_0_t(999) - fixed31_0_t(369))) == 630, "sg14::fixed_point test failed");
+static_assert(static_cast<float>((fixed15_16_t(246.875) - fixed15_16_t(123.75))) == 123.125, "sg14::fixed_point test failed");
+static_assert(static_cast<float>((fixed_point<std::int16_t, -4>(123.125) - fixed_point<std::int16_t, -4>(246.875))) == -123.75, "sg14::fixed_point test failed");
 
 // multiplication
-static_assert((ufixed8_0_t(0x55) * ufixed8_0_t(2)).get<int>() == 0xaa, "sg14::fixed_point test failed");
-static_assert((fixed15_16_t(123.75) * fixed15_16_t(44.5)).get<float>() == 5506.875, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((ufixed8_0_t(0x55) * ufixed8_0_t(2))) == 0xaa, "sg14::fixed_point test failed");
+static_assert(static_cast<float>((fixed15_16_t(123.75) * fixed15_16_t(44.5))) == 5506.875, "sg14::fixed_point test failed");
 #if defined(_SG14_FIXED_POINT_128)
-static_assert((fixed_point<std::uint64_t, -8>(1003006) * fixed_point<std::uint64_t, -8>(7)).get<int>() == 7021042, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((fixed_point<std::uint64_t, -8>(1003006) * fixed_point<std::uint64_t, -8>(7))) == 7021042, "sg14::fixed_point test failed");
 #endif
 
 // division
-static_assert((fixed_point<std::int8_t, -1>(63) / fixed_point<std::int8_t, -1>(-4)).get<float>() == -15.5, "sg14::fixed_point test failed");
-static_assert((fixed_point<std::int8_t, 1>(-255) / fixed_point<std::int8_t, 1>(-8)).get<int>() == 32, "sg14::fixed_point test failed");
-static_assert((fixed31_0_t(-999) / fixed31_0_t(3)).get<int>() == -333, "sg14::fixed_point test failed");
+static_assert(static_cast<float>((fixed_point<std::int8_t, -1>(63) / fixed_point<std::int8_t, -1>(-4))) == -15.5, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((fixed_point<std::int8_t, 1>(-255) / fixed_point<std::int8_t, 1>(-8))) == 32, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((fixed31_0_t(-999) / fixed31_0_t(3))) == -333, "sg14::fixed_point test failed");
 #if defined(_SG14_FIXED_POINT_128)
-static_assert((fixed_point<std::uint64_t, -8>(65535) / fixed_point<std::uint64_t, -8>(256)).get<int>() == 255, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((fixed_point<std::uint64_t, -8>(65535) / fixed_point<std::uint64_t, -8>(256))) == 255, "sg14::fixed_point test failed");
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -216,11 +216,11 @@ static_assert(fixed_point_mul_result_t<std::uint8_t, 0>::integer_digits == 16, "
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::safe_multiply
 
-static_assert(safe_multiply(fixed7_8_t(127), fixed7_8_t(127)).get<int>() == 16129, "sg14::safe_multiply test failed");
-static_assert(safe_multiply(ufixed4_4_t(15.9375), ufixed4_4_t(15.9375)).get<int>() == 254, "sg14::safe_multiply test failed");
-static_assert(safe_multiply(ufixed4_4_t(0.0625), ufixed4_4_t(0.0625)).get<float>() == 0, "sg14::safe_multiply test failed");
-static_assert(safe_multiply(ufixed8_0_t(1), ufixed8_0_t(1)).get<float>() == 0, "sg14::safe_multiply test failed");
-static_assert(safe_multiply(ufixed8_0_t(174), ufixed8_0_t(25)).get<float>() == 4096, "sg14::safe_multiply test failed");
+static_assert(static_cast<int>(safe_multiply(fixed7_8_t(127), fixed7_8_t(127))) == 16129, "sg14::safe_multiply test failed");
+static_assert(static_cast<int>(safe_multiply(ufixed4_4_t(15.9375), ufixed4_4_t(15.9375))) == 254, "sg14::safe_multiply test failed");
+static_assert(static_cast<float>(safe_multiply(ufixed4_4_t(0.0625), ufixed4_4_t(0.0625))) == 0, "sg14::safe_multiply test failed");
+static_assert(static_cast<float>(safe_multiply(ufixed8_0_t(1), ufixed8_0_t(1))) == 0, "sg14::safe_multiply test failed");
+static_assert(static_cast<float>(safe_multiply(ufixed8_0_t(174), ufixed8_0_t(25))) == 4096, "sg14::safe_multiply test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point_add_result_t
@@ -231,44 +231,44 @@ static_assert(fixed_point_add_result_t<std::int32_t, -25, 4>::integer_digits == 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::safe_add
 
-static_assert(safe_add(fixed_point<std::uint8_t, -1>(127), fixed_point<std::uint8_t, -1>(127)).get<int>() == 254, "sg14::safe_add test failed");
-static_assert(safe_add(ufixed4_4_t(15.5), ufixed4_4_t(14.25), ufixed4_4_t(13.5)).get<float>() == 43.25, "sg14::safe_add test failed");
+static_assert(static_cast<int>(safe_add(fixed_point<std::uint8_t, -1>(127), fixed_point<std::uint8_t, -1>(127))) == 254, "sg14::safe_add test failed");
+static_assert(static_cast<float>(safe_add(ufixed4_4_t(15.5), ufixed4_4_t(14.25), ufixed4_4_t(13.5))) == 43.25, "sg14::safe_add test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::abs
 
-static_assert(abs(fixed7_0_t(66)).get<int>() == 66, "sg14::abs test failed");
-static_assert(abs(fixed7_0_t(-123)).get<int>() == 123, "sg14::abs test failed");
-static_assert(abs(fixed63_0_t(9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::abs test failed");
-static_assert(abs(fixed63_0_t(-9223372036854775807)).get<std::int64_t>() == 9223372036854775807, "sg14::abs test failed");
-static_assert(abs(fixed7_8_t(-5)).get<int>() == 5, "sg14::abs test failed");
+static_assert(static_cast<int>(abs(fixed7_0_t(66))) == 66, "sg14::abs test failed");
+static_assert(static_cast<int>(abs(fixed7_0_t(-123))) == 123, "sg14::abs test failed");
+static_assert(static_cast<std::int64_t>(abs(fixed63_0_t(9223372036854775807))) == 9223372036854775807, "sg14::abs test failed");
+static_assert(static_cast<std::int64_t>(abs(fixed63_0_t(-9223372036854775807))) == 9223372036854775807, "sg14::abs test failed");
+static_assert(static_cast<int>(abs(fixed7_8_t(-5))) == 5, "sg14::abs test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::sqrt
 
-static_assert(sqrt(ufixed8_0_t(225)).get<int>() == 15, "sg14::sqrt test failed");
-static_assert(sqrt(fixed7_0_t(81)).get<int>() == 9, "sg14::sqrt test failed");
+static_assert(static_cast<int>(sqrt(ufixed8_0_t(225))) == 15, "sg14::sqrt test failed");
+static_assert(static_cast<int>(sqrt(fixed7_0_t(81))) == 9, "sg14::sqrt test failed");
 
-static_assert(sqrt(fixed_point<std::uint8_t, -1>(4)).get<int>() == 2, "sg14::sqrt test failed");
-static_assert(sqrt(fixed_point<std::int8_t, -2>(9)).get<int>() == 3, "sg14::sqrt test failed");
+static_assert(static_cast<int>(sqrt(fixed_point<std::uint8_t, -1>(4))) == 2, "sg14::sqrt test failed");
+static_assert(static_cast<int>(sqrt(fixed_point<std::int8_t, -2>(9))) == 3, "sg14::sqrt test failed");
 
-static_assert(sqrt(ufixed4_4_t(4)).get<int>() == 2, "sg14::sqrt test failed");
-static_assert(sqrt(fixed_point<std::int32_t, -24>(3.141592654)).get<float>() > 1.7724537849426, "sg14::sqrt test failed");
-static_assert(sqrt(fixed_point<std::int32_t, -24>(3.141592654)).get<float>() < 1.7724537849427, "sg14::sqrt test failed");
+static_assert(static_cast<int>(sqrt(ufixed4_4_t(4))) == 2, "sg14::sqrt test failed");
+static_assert(static_cast<float>(sqrt(fixed_point<std::int32_t, -24>(3.141592654))) > 1.7724537849426, "sg14::sqrt test failed");
+static_assert(static_cast<float>(sqrt(fixed_point<std::int32_t, -24>(3.141592654))) < 1.7724537849427, "sg14::sqrt test failed");
 #if defined(_SG14_FIXED_POINT_128)
-static_assert(sqrt(fixed63_0_t(9223372036854775807)).get<std::int64_t>() == 3037000499, "sg14::sqrt test failed");
+static_assert(static_cast<std::int64_t>(sqrt(fixed63_0_t(9223372036854775807))) == 3037000499, "sg14::sqrt test failed");
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::lerp
 
-static_assert(lerp(ufixed1_7_t(1), ufixed1_7_t(0), .5).get<float>() == .5f, "sg14::lerp test failed");
-static_assert(lerp(ufixed8_8_t(.125), ufixed8_8_t(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
-static_assert(lerp(ufixed16_16_t(42123.51323), ufixed16_16_t(432.9191), .812).get<unsigned>() == 8270, "sg14::lerp test failed");
+static_assert(static_cast<float>(lerp(ufixed1_7_t(1), ufixed1_7_t(0), .5)) == .5f, "sg14::lerp test failed");
+static_assert(static_cast<float>(lerp(ufixed8_8_t(.125), ufixed8_8_t(.625), .5)) == .375f, "sg14::lerp test failed");
+static_assert(static_cast<unsigned>(lerp(ufixed16_16_t(42123.51323), ufixed16_16_t(432.9191), .812)) == 8270, "sg14::lerp test failed");
 
-static_assert(lerp(fixed_point<std::int8_t, -6>(1), fixed_point<std::int8_t, -6>(0), .5).get<float>() == .5f, "sg14::lerp test failed");
-static_assert(lerp(fixed_point<std::int16_t, -10>(.125), fixed_point<std::int16_t, -10>(.625), .5).get<float>() == .375f, "sg14::lerp test failed");
-static_assert(lerp(fixed_point<std::int32_t, -6>(.125), fixed_point<std::int32_t, -6>(.625), .25).get<float>() == .25f, "sg14::lerp test failed");
+static_assert(static_cast<float>(lerp(fixed_point<std::int8_t, -6>(1), fixed_point<std::int8_t, -6>(0), .5)) == .5f, "sg14::lerp test failed");
+static_assert(static_cast<float>(lerp(fixed_point<std::int16_t, -10>(.125), fixed_point<std::int16_t, -10>(.625), .5)) == .375f, "sg14::lerp test failed");
+static_assert(static_cast<float>(lerp(fixed_point<std::int32_t, -6>(.125), fixed_point<std::int32_t, -6>(.625), .25)) == .25f, "sg14::lerp test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // fixed_point specializations

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -62,6 +62,36 @@ static_assert(_impl::capacity<15>::value == 4, "sg14::_impl::capacity test faile
 static_assert(_impl::capacity<16>::value == 5, "sg14::_impl::capacity test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
+// sg14::_impl::necessary_repr_t
+
+static_assert(std::is_same<_impl::necessary_repr_t<1, false>, std::uint8_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<1, true>, std::int8_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<8, false>, std::uint8_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<8, true>, std::int8_t>::value, "sg14::_impl::necessary_repr_t");
+
+static_assert(std::is_same<_impl::necessary_repr_t<9, false>, std::uint16_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<9, true>, std::int16_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<16, false>, std::uint16_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<16, true>, std::int16_t>::value, "sg14::_impl::necessary_repr_t");
+
+static_assert(std::is_same<_impl::necessary_repr_t<17, false>, std::uint32_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<17, true>, std::int32_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<32, false>, std::uint32_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<32, true>, std::int32_t>::value, "sg14::_impl::necessary_repr_t");
+
+static_assert(std::is_same<_impl::necessary_repr_t<33, false>, std::uint64_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<33, true>, std::int64_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<64, false>, std::uint64_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<64, true>, std::int64_t>::value, "sg14::_impl::necessary_repr_t");
+
+#if defined(_SG14_FIXED_POINT_128)
+static_assert(std::is_same<_impl::necessary_repr_t<65, false>, std::uint128_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<65, true>, std::int64_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<128, false>, std::uint64_t>::value, "sg14::_impl::necessary_repr_t");
+static_assert(std::is_same<_impl::necessary_repr_t<128, true>, std::int64_t>::value, "sg14::_impl::necessary_repr_t");
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::fixed_point
 
@@ -387,4 +417,65 @@ static_assert(ufixed0_128_t::fractional_digits == 128, "fixed_point specializati
 static_assert(ufixed1_127_t::fractional_digits == 127, "fixed_point specializations test failed");
 static_assert(ufixed64_64_t::fractional_digits == 64, "fixed_point specializations test failed");
 static_assert(ufixed128_0_t::fractional_digits == 0, "fixed_point specializations test failed");
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// sg14::make_fixed
+
+// integer_digits
+static_assert(std::is_same<make_fixed<0, 7, true>, fixed0_7_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<1, 6, true>, fixed1_6_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<3, 4, true>, fixed3_4_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<4, 3, true>, fixed4_3_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<7, 0, true>, fixed7_0_t>::value, "make_fixed specializations test failed");
+
+static_assert(std::is_same<make_fixed<0, 8, false>, ufixed0_8_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<1, 7, false>, ufixed1_7_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<4, 4, false>, ufixed4_4_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<8, 0, false>, ufixed8_0_t>::value, "make_fixed specializations test failed");
+
+static_assert(std::is_same<make_fixed<0, 15, true>, fixed0_15_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<1, 14, true>, fixed1_14_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<7, 8, true>, fixed7_8_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<8, 7, true>, fixed8_7_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<15, 0, true>, fixed15_0_t>::value, "make_fixed specializations test failed");
+
+static_assert(std::is_same<make_fixed<0, 16, false>, ufixed0_16_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<1, 15, false>, ufixed1_15_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<8, 8, false>, ufixed8_8_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<16, 0, false>, ufixed16_0_t>::value, "make_fixed specializations test failed");
+
+static_assert(std::is_same<make_fixed<0, 31, true>, fixed0_31_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<1, 30, true>, fixed1_30_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<15, 16, true>, fixed15_16_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<16, 15, true>, fixed16_15_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<31, 0, true>, fixed31_0_t>::value, "make_fixed specializations test failed");
+
+static_assert(std::is_same<make_fixed<0, 32, false>, ufixed0_32_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<1, 31, false>, ufixed1_31_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<16, 16, false>, ufixed16_16_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<32, 0, false>, ufixed32_0_t>::value, "make_fixed specializations test failed");
+
+static_assert(std::is_same<make_fixed<0, 63, true>, fixed0_63_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<1, 62, true>, fixed1_62_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<31, 32, true>, fixed31_32_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<32, 31, true>, fixed32_31_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<63, 0, true>, fixed63_0_t>::value, "make_fixed specializations test failed");
+
+static_assert(std::is_same<make_fixed<0, 64, false>, ufixed0_64_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<1, 63, false>, ufixed1_63_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<32, 32, false>, ufixed32_32_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<64, 0, false>, ufixed64_0_t>::value, "make_fixed specializations test failed");
+
+#if defined(_SG14_FIXED_POINT_128)
+static_assert(std::is_same<make_fixed<0, 127, true>, fixed0_127_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<1, 126, true>, fixed1_126_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<63, 64, true>, fixed63_64_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<64, 63, true>, fixed64_63_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<127, 0, true>, fixed127_0_t>::value, "make_fixed specializations test failed");
+
+static_assert(std::is_same<make_fixed<0, 128, false>, ufixed0_128_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<1, 127, false>, ufixed1_127_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<64, 64, false>, ufixed64_64_t>::value, "make_fixed specializations test failed");
+static_assert(std::is_same<make_fixed<128, 0, false>, ufixed128_0_t>::value, "make_fixed specializations test failed");
 #endif

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -35,7 +35,7 @@ static_assert(_impl::shift_right<-8, std::int16_t>(-123) == -31488, "sg14::_impl
 static_assert(_impl::shift_left<-8, std::uint16_t>((std::uint16_t)0x1234) == 0x12, "sg14::_impl::shift_left test failed");
 static_assert(_impl::shift_left<-8, std::uint16_t>((std::uint8_t)0x1234) == 0x0, "sg14::_impl::shift_left test failed");
 static_assert(_impl::shift_left<-8, std::uint8_t>((std::uint16_t)0x1234) == 0x12, "sg14::_impl::shift_left test failed");
-static_assert(_impl::shift_left<-8, std::int16_t>(-31488) == -123, "sg14::_impl::shift_right test failed");
+static_assert(_impl::shift_left<-8, std::int16_t>(-31488) == -123, "sg14::_impl::shift_left test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::_impl::pow2


### PR DESCRIPTION
A few usability improvements:
* The `get` function is replaced with a conversion operator marked `explicit`. I believe this is the modern way to allow all the usual explicit casts without producing any hard-to-spot conversions.
* `fixed_point_by_integer_digits_t` renamed to `make_fixed_from_repr` which is slightly better but still not great
* `make_fixed` creates a fixed_point type given the desired number of integer, fractional and sign bits.
* updates fixed_point.md document