### PR TITLE
changes PlatformToolset in VS2015 SG14 project

### DIFF
--- a/VS2015/SG14/SG14/SG14.vcxproj
+++ b/VS2015/SG14/SG14/SG14.vcxproj
@@ -21,13 +21,14 @@
     <ProjectGuid>{71063685-C50D-4C69-AE56-7184DE4FECCB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>SG14</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>Visual Studio 2015 (v140)</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>


### PR DESCRIPTION
- hopefully prevents error message during build reported in
  https://github.com/WG21-SG14/SG14/issues/19

@schmaltzlicker , perhaps you could double-check that both VS2015 are building OK on your system. It looked like maybe SG14_test was fixed by SG14 was not. 