### PR TITLE
Changes to fixed_point API, proposal and tests as result of forum feedback

### DIFF
--- a/Docs/Proposals/Fixed_Point_Library_Proposal.md
+++ b/Docs/Proposals/Fixed_Point_Library_Proposal.md
@@ -13,13 +13,12 @@ arithmetic using built-in integral types.
 ## II. Motivation
 
 Floating-point types are an exceedingly versatile and widely supported
-method of expressing real numbers on modern architectures. However,
-there are certain situations where fixed-point arithmetic is
-preferable.
+method of expressing real numbers on modern architectures.
 
-Some system lack native floating-point registers and must emulate them
-in software. Many others are capable of performing some or
-all operations more efficiently using integer arithmetic. Certain
+However, there are certain situations where fixed-point arithmetic is
+preferable. Some system lack native floating-point registers and must
+emulate them in software. Many others are capable of performing some
+or all operations more efficiently using integer arithmetic. Certain
 applications can suffer from the variability in precision which comes
 from a dynamic radix point [\[1\]](http://www.pathengine.com/Contents/Overview/FundamentalConcepts/WhyIntegerCoordinates/page.php).
 In situations where a variable exponent is not desired, it takes
@@ -56,41 +55,81 @@ order:
 
 ### Class Template
 
-Fixed-point numbers are specializations of `template <typename
-REPR_TYPE, int EXPONENT> class fixed_point` where:
+Fixed-point numbers are specializations of
 
-* `REPR_TYPE` implies the underlying type used to store the value. A
-  type which satisfies `is_integral` is an ideal choice. The size of
-  the resulting type will be `sizeof(REPR_TYPE)` and it will be signed
-  iff `is_signed<REPR_TYPE>::value` is true.
+    template <typename REPR_TYPE, int EXPONENT>
+    class fixed_point
 
-  The default is `int`.
+where the template parameters are described as follows.
 
-* `EXPONENT` is the equivalent of the exponent field in a
-  floating-point type and shifts the stored value by the requisite
-  number of bits necessary to produce the desired range.
+#### `REPR_TYPE` Type Template Parameter
 
-  The default value is dependent on `REPR_TYPE` and ensures that half
-  of the bits of the type are allocated to fractional digits. The
-  other half go to integer digits and the signe bit.
+This parameter identifies the capacity and signedness of the
+underlying type used to represent the value. In other words, the size
+of the resulting type will be `sizeof(REPR_TYPE)` and it will be
+signed iff `is_signed<REPR_TYPE>::value` is true. The default is
+`int`.
 
-Some example specializations include the default -- typically a 32-bit
-object with a sign bit, 15 integer digits and 16 fractional digits:
+`REPR_TYPE` must be a fundamental integral type and should not be the
+largest size. Suitable types include: `std::int8_t`, `std::uint8_t`,
+`std::int16_t`, `std::uint16_t`, `std::int32_t` and `std::uint32_t`.
+In limited situations, `std::int64_t` and `std::uint64_t` can be used.
+The  reasons for these limitations relate to the difficulty in finding
+a type that is suitable for performing lossless integer
+multiplication.
 
-    fixed_point<>
+#### `EXPONENT` Non-Type Template Parameter
 
-an unsigned 16-bit type with 8 integer digits and 8 fractional digits:
+The exponent of a fixed-point type is the equivalent of the exponent
+field in a floating-point type and shifts the stored value by the
+requisite number of bits necessary to produce the desired range.
 
-    fixed_point<uint16_t>
+The default value is dependent on `REPR_TYPE` and ensures that half of
+the bits of the type are allocated to fractional digits. The other
+half go to integer digits and (if `REPR_TYPE` is signed) the sign bit.
 
-a signed 32-bit type which can represent half values:
+The resolution of a specialization of `fixed_point` is
 
-    fixed_point<int32_t, -1>
+    2 ^ EXPONENT
 
-and an unsigned 8-bit type with 8 fractional digits that can be used
-to store values in the range, [0, 1):
+and the minimum and maximum values are
 
-    fixed_point<uint8_t, -8>
+    std::numeric_limits<REPR_TYPE>::min() * 2 ^ EXPONENT
+
+and
+
+    std::numeric_limits<REPR_TYPE>::max() * 2 ^ EXPONENT
+
+respectively.
+
+### `make_fixed` and `make_ufixed` Helper Type
+
+The `EXPONENT` template parameter is versatile and concise. It is an
+intuitive scale to use when considering the full range of positive and
+negative exponents a fixed-point type might possess. It also
+corresponds to the exponent field of built-in floating-point types.
+
+However, most fixed-point formats can be described more intuitively by
+the cardinal number of integer and/or fractional digits they contain.
+Most users will prefer to distinguish fixed-point types using these
+parameters.
+
+For this reason, two 'named constructors' are defined. They take the
+form of helper types in the style of `make_signed`.
+
+These aliases are declared as:
+
+    template <unsigned INTEGER_DIGITS, unsigned FRACTIONAL_DIGITS, bool IS_SIGNED = true>
+  	using make_fixed;
+
+and
+
+    template <unsigned INTEGER_DIGITS, unsigned FRACTIONAL_DIGITS>
+    using make_ufixed;
+
+They resolve to a `fixed_point` specialization with the given
+signedness and number of integer and fractional digits. They may
+contain additional integer and fractional digits.
 
 ### Conversion
 
@@ -102,61 +141,9 @@ during conversion, no effort is made to avoid rounding errors.
 Whatever would happen when converting to and from an integer type
 largely applies to `fixed_point` objects also. For example:
 
-    fixed_point<uint8_t, -4>(.006) == fixed_point<uint8_t, -4>(0)
+    make_ufixed<4, 4>(.006) == make_ufixed<4, 4>(0)
 
-...equates to `true` and is considered a tolerable rounding error.
-
-### Named Constructors
-
-The `EXPONENT` template parameter is a versatile way to express the
-full range of values a type might contain - including very large
-positive and negative values. However, it is not necessarily the most
-intuitive choice for a typical user.
-
-There are a number of conventions by which fixed-point number types
-are traditionally expressed. And because the template parameters of
-`fixed_point` do not necessarily fit with these conventions, a number
-of named constructors are defined in the spirit of existing `make_X`
-functions to make specialization of `fixed_point<>` more convenient.
-
-#### `make_fixed`
-
-To create a specialization with *I* integer digits, *F* fractional
-digits and signed digit *S*, there is:
-
-    template <unsigned I, unsigned F, bool S = true> make_fixed
-
-This alias automatically determines what underlying type is needed to
-accommodate the desired amount of precisions. For example,
-
-    make_fixed<8, 11, true>
-
-is guaranteed to be a signed fixed-point type with 8 integer digits
-and at least 11 fractional digits. As there is no standard 20-bit
-integer type, a `REPR_TYPE` of `int32_t` is used and an additional 12
-bits are devoted to fractional digits: `fixed_point<int32_t, -23>`.
-
-#### `make_fixed_from_repr`
-
-When discussing a fixed-point type, the number of fractional digits
-often hogs the limelight. It is really the number of integer digits
-that are - literally - most significant. In cases where the underlying
-type and the number of integer digits are known, one can use
-
-    template <typename REPR_TYPE, int I> make_fixed_from_repr
-
-to instantiate a type. For example:
-
-    make_fixed_from_repr<uint16_t, 4>
-
-is an alias for a 16-bit unsigned type, capable of storing value, 15.
-
-#### `make_fixed_from_pair`
-
-When the greater of two fixed-point types is required, such as when
-comparing heterogeneous values or taking their maximum, use:
-
-    make_fixed_from_pair<FIXED_POINT_1, FIXED_POINT_2>
+...equates to `true` and is considered a acceptable rounding error.
 
 ### Arithmetic Operators
 
@@ -168,10 +155,11 @@ right hand parameter of bit shift operators.)
 Because of this choice, arithmetic operators carry a risk of overflow.
 For instance,
 
-    fixed_point<uint8_t, -4>(15) * fixed_point<uint8_t, -4>(15)
+    make_fixed<4, 3>(15) + make_fixed<4, 3>(1)
 
-returns `fixed_point<uint8_t, -4>(1)` as the input type does not have
-the capacity to represent the value, 225.
+produces undefined behavior because a type with 4 integer bits cannot
+store value 16. (Note that unsigned types also overflow - unlike their
+unsigned integer equivalents.)
 
 This represents the first of three alternative approaches to dealing
 with overflow:
@@ -187,26 +175,27 @@ For arithmetic operators, choice 1) is preferred because it most
 closely follows the behavior of integer types. Thus it should cause
 the least surprise to the fewest users. This makes it far easier to
 reason about in code where functions are written with a particular
-type in mind.
+type in mind. It also requires the least computation.
 
 Choices 2) and 3) are more robust to overflow events. However, they
 represent different trade-offs and neither one is the best fit in all
-situations. For these reasons, they are offered via named functions.
+situations. For these reasons, they are offered via named functions
+instead.
 
 ### Type Promotion
 
 Function template, `promote`, borrows a term from the language feature
 which avoids integer overflow prior to certain operations. It takes a
-`fixed_point<>` object and returns the same value represented by a
-larger `fixed_point<>` specialization.
+`fixed_point` object and returns the same value represented by a
+larger `fixed_point` specialization.
 
 For example,
 
-    promote(fixed_point<int8_t, -2>(15.5))
+    promote(make_fixed<5, 2>(15.5))
 
 is equivalent to
 
-    fixed_point<int16_t, -4>(15.5)
+    make_fixed<11, 4>(15.5)
 
 Complimentary function template, `demote`, inverts the process,
 returning a value of a smaller type.
@@ -230,21 +219,21 @@ values which prevent overflow in the vast majority of cases. The
 Firstly, because the capacity of the return type is not increased,
 precision may be lost. For example:
 
-    shift_square(fixed_point<uint8_t, -4>(15.9375))
+    shift_square(make_ufixed<4, 4>(15.9375))
 
-returns `fixed_point<uint8_t, 0>(254)`. This result is far closer to
+returns `make_ufixed<8, 0>(254)`. This result is far closer to
 the correct value than the result returned by `operator *`.
 
 Secondly, there are rare cases where overflow can still occur due to
 the nature of twos-compliment binary arithmetic and the *most negative
 number*. For instance, the value of
 
-    shift_square(fixed_point<int8_t, 0>(-128))
+    shift_square(make_fixed<7, 0>(-128))
 
 is zero because 16384 cannot be represented in a
 `fixed_point<uint8_t, 6>` type.
 
-### Overflow and Underflow
+### Underflow
 
 The major disadvantage of the way in which `shift_` functions protect
 the more significant digits is that the less insignificant digits are
@@ -253,7 +242,7 @@ the value becomes zero.
 
 For example,
 
-    shift_square(fixed_point<uint8_t, 0>(15))
+    shift_square(make_ufixed<8, 0>(15))
 
 causes the object to be flushed to zero.
 
@@ -261,9 +250,9 @@ While often not as serious as overflow, underflow can cause knock-on
 effects, such as when a flushed value is subsequently used as a
 divisor.
 
-There is a strong desire to catch situations where a `fixed_point`
-value transitions to a flushed state. However, it is unacceptable that
-this should necessarily require a run-time check.
+Although there is a strong desire to catch situations where a
+`fixed_point` value transitions to a flushed state, it is unacceptable
+that this should necessarily require a run-time check.
 
 For this reason, it is left to the user to avoid flush events and for
 such events to result in undefined behavior. This is not an ideal
@@ -288,32 +277,23 @@ The following example calculates the magnitude of a 3-dimensional vector.
 Calling the above function as follows
 
     static_cast<double>(magnitude(
-        fixed_point<uint16_t, -12>(1),
-        fixed_point<uint16_t, -12>(4),
-        fixed_point<uint16_t, -12>(9)));
+        make_ufixed<4, 12>(1),
+        make_ufixed<4, 12>(4),
+        make_ufixed<4, 12>(9)));
 
 returns the value, 9.890625.
 
 ## V. Technical Specification
 
-### Header
-
-All proposed additions to the library are contained in header,
-`<fixed_point>`.
-
-### Class template `fixed_point`
-
-#### Header `<fixed_point>` Synopsis
+### Header \<fixed_point\> Synopsis
 
     namespace std {
       template <typename REPR_TYPE, int EXPONENT> class fixed_point;
 
       template <unsigned INTEGER_DIGITS, unsigned FRACTIONAL_DIGITS, bool IS_SIGNED = true>
         using make_fixed;
-      template <typename REPR_TYPE, int INTEGER_BITS>
-        using make_fixed_from_repr;
-      template <typename LHS_FP, typename RHS_FP>
-        using make_fixed_from_pair;
+      template <unsigned INTEGER_DIGITS, unsigned FRACTIONAL_DIGITS>
+        using make_ufixed;
 
       template <typename FIXED_POINT>
         using fixed_point_promotion_t;
@@ -371,57 +351,57 @@ All proposed additions to the library are contained in header,
           constexpr shift_sqrt(const FIXED_POINT & root) noexcept;
     }
 
-#### Class template `fixed_point<>`
+#### `fixed_point<>` Class Template
 
-  template <typename REPR_TYPE, int EXPONENT>
-  class fixed_point
-  {
-  public:
-    using repr_type;
+    template <typename REPR_TYPE, int EXPONENT>
+    class fixed_point
+    {
+    public:
+      using repr_type;
 
-    constexpr static int exponent;
-    constexpr static int digits;
-    constexpr static int integer_digits;
-    constexpr static int fractional_digits;
+      constexpr static int exponent;
+      constexpr static int digits;
+      constexpr static int integer_digits;
+      constexpr static int fractional_digits;
 
-    constexpr fixed_point() noexcept;
-    template <typename S>
-      explicit constexpr fixed_point(S s) noexcept;
-    template <typename FROM_REPR_TYPE, int FROM_EXPONENT>
-      explicit constexpr fixed_point(fixed_point<FROM_REPR_TYPE, FROM_EXPONENT> const & rhs) noexcept;
+      constexpr fixed_point() noexcept;
+      template <typename S>
+        explicit constexpr fixed_point(S s) noexcept;
+      template <typename FROM_REPR_TYPE, int FROM_EXPONENT>
+        explicit constexpr fixed_point(fixed_point<FROM_REPR_TYPE, FROM_EXPONENT> const & rhs) noexcept;
 
-    template <typename S>
-      fixed_point & operator=(S s) noexcept;
-    template <typename FROM_REPR_TYPE, int FROM_EXPONENT>
-      fixed_point & operator=(fixed_point<FROM_REPR_TYPE, FROM_EXPONENT> const & rhs) noexcept
+      template <typename S>
+        fixed_point & operator=(S s) noexcept;
+      template <typename FROM_REPR_TYPE, int FROM_EXPONENT>
+        fixed_point & operator=(fixed_point<FROM_REPR_TYPE, FROM_EXPONENT> const & rhs) noexcept
 
-    template <typename S>
-      explicit constexpr operator S() const noexcept;
-    explicit constexpr operator bool() const noexcept;
+      template <typename S>
+        explicit constexpr operator S() const noexcept;
+      explicit constexpr operator bool() const noexcept;
 
-    constexpr repr_type data() const noexcept;
-    static constexpr fixed_point from_data(repr_type repr) noexcept;
+      constexpr repr_type data() const noexcept;
+      static constexpr fixed_point from_data(repr_type repr) noexcept;
 
-    friend constexpr bool operator==(fixed_point const & lhs, fixed_point const & rhs) noexcept;
-    friend constexpr bool operator!=(fixed_point const & lhs, fixed_point const & rhs) noexcept;
-    friend constexpr bool operator>(fixed_point const & lhs, fixed_point const & rhs) noexcept;
-    friend constexpr bool operator<(fixed_point const & lhs, fixed_point const & rhs) noexcept;
-    friend constexpr bool operator>=(fixed_point const & lhs, fixed_point const & rhs) noexcept;
-    friend constexpr bool operator<=(fixed_point const & lhs, fixed_point const & rhs) noexcept;
+      friend constexpr bool operator==(fixed_point const & lhs, fixed_point const & rhs) noexcept;
+      friend constexpr bool operator!=(fixed_point const & lhs, fixed_point const & rhs) noexcept;
+      friend constexpr bool operator>(fixed_point const & lhs, fixed_point const & rhs) noexcept;
+      friend constexpr bool operator<(fixed_point const & lhs, fixed_point const & rhs) noexcept;
+      friend constexpr bool operator>=(fixed_point const & lhs, fixed_point const & rhs) noexcept;
+      friend constexpr bool operator<=(fixed_point const & lhs, fixed_point const & rhs) noexcept;
 
-    friend constexpr fixed_point operator-(fixed_point const & rhs) noexcept;
-    friend constexpr fixed_point operator+(fixed_point const & lhs, fixed_point const & rhs) noexcept;
-    friend constexpr fixed_point operator-(fixed_point const & lhs, fixed_point const & rhs) noexcept;
-    friend constexpr fixed_point operator*(fixed_point const & lhs, fixed_point const & rhs) noexcept;
-    friend constexpr fixed_point operator/(fixed_point const & lhs, fixed_point const & rhs) noexcept;
+      friend constexpr fixed_point operator-(fixed_point const & rhs) noexcept;
+      friend constexpr fixed_point operator+(fixed_point const & lhs, fixed_point const & rhs) noexcept;
+      friend constexpr fixed_point operator-(fixed_point const & lhs, fixed_point const & rhs) noexcept;
+      friend constexpr fixed_point operator*(fixed_point const & lhs, fixed_point const & rhs) noexcept;
+      friend constexpr fixed_point operator/(fixed_point const & lhs, fixed_point const & rhs) noexcept;
 
-    friend fixed_point & operator+=(fixed_point & lhs, fixed_point const & rhs) noexcept;
-    friend fixed_point & operator-=(fixed_point & lhs, fixed_point const & rhs) noexcept;
-    friend fixed_point & operator*=(fixed_point & lhs, fixed_point const & rhs) noexcept;
-    friend fixed_point & operator/=(fixed_point & lhs, fixed_point const & rhs) noexcept;
+      friend fixed_point & operator+=(fixed_point & lhs, fixed_point const & rhs) noexcept;
+      friend fixed_point & operator-=(fixed_point & lhs, fixed_point const & rhs) noexcept;
+      friend fixed_point & operator*=(fixed_point & lhs, fixed_point const & rhs) noexcept;
+      friend fixed_point & operator/=(fixed_point & lhs, fixed_point const & rhs) noexcept;
 
-    // ...
-  };
+      // ...
+    };
 
 ## VI. Future Issues
 
@@ -494,22 +474,25 @@ of techniques is capable of producing superior results.
 
 For instance, consider the following expression:
 
-    fixed_point<uint8_t, -6> three(3);
+    make_ufixed<2, 6> three(3);
     auto n = shift_square(shift_square(three));
 
-The type of `n` is `fixed_point<uint8_t, 0>` but its value does not
+The type of `n` is `make_ufixed<8, 0>` but its value does not
 exceed 81. Hence, an unused integer bit has been allocated. It may be
 possible to track more accurate limits in the same manner as the
 bounded::integer library in order to improve the precision of types
 returned by `shift_` functions. For this reason, details surrounding
 these return types are omitted from this proposal.
 
-(Note: bounded::integer is already supported by fixed-point library,
-fp [\[4\]](https://github.com/mizvekov/fp).)
+Notes:
+* Bounded::integer is already supported by fixed-point library,
+fp [\[4\]](https://github.com/mizvekov/fp).
+* A similar library is the boost constrained_value library
+[\[5\]](http://rk.hekko.pl/constrained_value/).
 
 ### Alternative Policies
 
-The behavior of the types specialized from `fixed_point<>` represent
+The behavior of the types specialized from `fixed_point` represent
 one sub-set of all potentially desirable behaviors. Alternative
 characteristics include:
 
@@ -523,7 +506,7 @@ to add a third template parameter containing bit flags. The default
 set of values would reflect `fixed_point` as it stands currently.
 
 An example of a fixed-point proposal which takes a similar approach to
-rounding and error cases can be found in N3352 [\[5\]](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3352.html).
+rounding and error cases can be found in N3352 [\[6\]](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3352.html).
 
 ## VII. References
 
@@ -531,4 +514,5 @@ rounding and error cases can be found in N3352 [\[5\]](http://www.open-std.org/j
 2. N1169, Extensions to support embedded processors, <http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1169.pdf>
 3. C++ bounded::integer library, <http://doublewise.net/c++/bounded/>
 4. fp, C++14 Fixed Point Library, <https://github.com/mizvekov/fp>
-5. N3352, C++ Binary Fixed-Point Arithmetic, <http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3352.html>
+5. Boost Constrained Value Libarary, <http://rk.hekko.pl/constrained_value/>
+6. N3352, C++ Binary Fixed-Point Arithmetic, <http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3352.html>

--- a/SG14_test/fixed_point_test.cpp
+++ b/SG14_test/fixed_point_test.cpp
@@ -89,53 +89,52 @@ namespace sg14_test
 		
 		static_assert(fixed_point<>::fractional_digits == _impl::num_bits<int>() / 2, "Incorrect information in proposal section, Class Template");
 
+		// Named Constructors
+
 		// Conversion
 
-		auto conversion_lhs = fixed_point<uint8_t, -4>(.006);
-		auto conversion_rhs = fixed_point<uint8_t, -4>(0);
+		auto conversion_lhs = make_ufixed<4, 4>(.006);
+		auto conversion_rhs = make_ufixed<4, 4>(0);
 		static_assert(is_same<decltype(conversion_lhs), decltype(conversion_rhs)>::value, "Incorrect information in proposal section, Conversion");
 		ASSERT_EQUAL(conversion_lhs, conversion_rhs);
 
-		// Named Constructors
-
-		static_assert(is_same<make_fixed<8, 11, true>, fixed_point<int32_t, -23>>::value, "Incorrect information in proposal section, Named Constructors");
-		static_assert(is_same<make_fixed_from_repr<uint16_t, 4>, fixed_point<uint16_t, -12>>::value, "Incorrect information in proposal section, Named Constructors");
-
 		// Arithmetic Operators
-
-		auto arithmetic_op = fixed_point<uint8_t, -4>(15) * fixed_point<uint8_t, -4>(15);
-		static_assert(is_same<decltype(arithmetic_op), fixed_point<uint8_t, -4>>::value, "Incorrect information in proposal section, Arithmetic Operators");
-		ASSERT_EQUAL(static_cast<int>(arithmetic_op), 1);
+		static_assert(static_cast<int>(make_fixed<4, 3>(15) + make_fixed<4, 3>(1)) != 16, "Incorrect information in proposal section, Arithmetic Operators");
 
 		// Type Promotion and Demotion Functions
-		auto type_promotion = promote(fixed_point<int8_t, -2>(15.5));
-		static_assert(is_same<decltype(type_promotion), fixed_point<int16_t, -4>>::value, "Incorrect information in proposal section, Type Promotion and Demotion Functions");
+		auto type_promotion = promote(make_fixed<5, 2>(15.5));
+		static_assert(is_same<decltype(type_promotion), make_fixed<11, 4>>::value, "Incorrect information in proposal section, Type Promotion and Demotion Functions");
 		ASSERT_EQUAL(static_cast<float>(type_promotion), 15.5);
 
 		// Named Arithmetic Functions
-		auto sq = shift_multiply(fixed_point<uint8_t, -4>(15.9375), fixed_point<uint8_t, -4>(15.9375));
+		auto sq = shift_multiply(make_ufixed<4, 4>(15.9375), make_ufixed<4, 4>(15.9375));
 		ASSERT_EQUAL(static_cast<double>(sq), 254);
 
-		auto most_negative = fixed_point<int8_t, 0>(-128);
+		auto most_negative = make_fixed<7, 0>(-128);
 		ASSERT_EQUAL(static_cast<int>(most_negative), -128);
 		ASSERT_EQUAL(static_cast<int>(shift_square(promote(most_negative))), 16384);
 		auto square = shift_square(most_negative);
 		static_assert(is_same<decltype(square), fixed_point<uint8_t, 6>>::value, "wrong type mentioned in proposal");
 		ASSERT_EQUAL(static_cast<int>(square), 0);
 
-		// Overflow and Underflow
-		auto underflow = shift_square(fixed_point<uint8_t, 0>(15));
-		static_assert(is_same<decltype(underflow), fixed_point<uint8_t, 8>>::value, "unexpected type returned by shift_square");
-		ASSERT_TRUE(! underflow);
+		// Underflow
+		static_assert(static_cast<int>(shift_square(make_ufixed<8, 0>(15))) != 15 * 15, "wrong behavior reported in 'Overflow and Underflow' section");
 
 		// Examples
 		static_assert(static_cast<double>(magnitude(
-			fixed_point<uint16_t, -12>(1),
-			fixed_point<uint16_t, -12>(4),
-			fixed_point<uint16_t, -12>(9))) == 9.890625, "unexpected result from magnitude");
+			make_ufixed<4, 12>(1),
+			make_ufixed<4, 12>(4),
+			make_ufixed<4, 12>(9))) == 9.890625, "unexpected result from magnitude");
 
 		static fixed_point<> zero;
 		ASSERT_EQUAL(zero, fixed_point<>(0));
+
+		// Bounded Integers
+		make_ufixed<2, 6> three(3);
+		auto n = shift_square(shift_square(three));
+		ASSERT_EQUAL(static_cast<int>(n), 81);
+		static_assert(is_same<decltype(n), make_ufixed<8, 0>>::value, "bad assumption about type in 'Bounded Integers' section");
+		ASSERT_EQUAL(static_cast<int>(make_ufixed<7, 1>(81)), 81);
 	}
 }
 
@@ -275,15 +274,15 @@ static_assert(std::is_same<fixed_point<int, _impl::num_bits<int>() / -2>, fixed_
 // conversion
 
 // exponent == 0
-static_assert(static_cast<float>(ufixed8_0_t(12.34f)) == 12.f, "sg14::fixed_point test failed");
-static_assert(static_cast<double>(ufixed16_0_t(12.34f)) == 12.f, "sg14::fixed_point test failed");
-static_assert(static_cast<long double>(ufixed32_0_t(12.34f)) == 12.f, "sg14::fixed_point test failed");
-static_assert(static_cast<float>(ufixed64_0_t(12.34f)) == 12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(make_ufixed<8, 0>(12.34f)) == 12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(make_ufixed<16, 0>(12.34f)) == 12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<long double>(make_ufixed<32, 0>(12.34f)) == 12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(make_ufixed<64, 0>(12.34f)) == 12.f, "sg14::fixed_point test failed");
 
-static_assert(static_cast<double>(fixed7_0_t(-12.34f)) == -12.f, "sg14::fixed_point test failed");
-static_assert(static_cast<long double>(fixed15_0_t(-12.34f)) == -12.f, "sg14::fixed_point test failed");
-static_assert(static_cast<float>(fixed31_0_t(-12.34f)) == -12.f, "sg14::fixed_point test failed");
-static_assert(static_cast<double>(fixed63_0_t(-12.34f)) == -12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(make_fixed<7, 0>(-12.34f)) == -12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<long double>(make_fixed<15, 0>(-12.34f)) == -12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(make_fixed<31, 0>(-12.34f)) == -12.f, "sg14::fixed_point test failed");
+static_assert(static_cast<double>(make_fixed<63, 0>(-12.34f)) == -12.f, "sg14::fixed_point test failed");
 
 // exponent = -1
 static_assert(static_cast<float>(fixed_point<std::uint8_t, -1>(127.5)) == 127.5, "sg14::fixed_point test failed");
@@ -335,43 +334,11 @@ static_assert(static_cast<int>(fixed_point<std::int8_t, 1>(254)) == 254, "sg14::
 static_assert(static_cast<int>(fixed_point<std::int8_t, 1>(-5)) == -6, "sg14::fixed_point test failed");
 
 // conversion between fixed_point specializations
-static_assert(static_cast<float>(ufixed4_4_t(fixed7_8_t(1.5))) == 1.5, "sg14::fixed_point test failed");
-static_assert(static_cast<float>(ufixed8_8_t(fixed3_4_t(3.25))) == 3.25, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(make_ufixed<4, 4>(make_fixed<7, 8>(1.5))) == 1.5, "sg14::fixed_point test failed");
+static_assert(static_cast<float>(make_ufixed<8, 8>(make_fixed<3, 4>(3.25))) == 3.25, "sg14::fixed_point test failed");
 static_assert(static_cast<int>(fixed_point<std::uint8_t, 4>(fixed_point<std::int16_t, -4>(768))) == 768, "sg14::fixed_point test failed");
 static_assert(static_cast<float>(fixed_point<std::uint64_t, -48>(fixed_point<std::uint32_t, -24>(3.141592654))) > 3.1415923f, "sg14::fixed_point test failed");
 static_assert(static_cast<float>(fixed_point<std::uint64_t, -48>(fixed_point<std::uint32_t, -24>(3.141592654))) < 3.1415927f, "sg14::fixed_point test failed");
-
-// closed_unit
-static_assert(static_cast<double>(closed_unit<std::uint8_t>(.5)) == .5, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(closed_unit<std::uint16_t>(.125f)) == .125f, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(closed_unit<std::uint16_t>(.640625l)) == .640625, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(closed_unit<std::uint16_t>(1.640625)) == 1.640625f, "sg14::closed_unit test failed");
-static_assert(static_cast<std::uint64_t>(closed_unit<std::uint16_t>(1u)) == 1, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(closed_unit<std::uint16_t>(2)) != 2, "sg14::closed_unit test failed");	// out-of-range test
-
-static_assert(static_cast<double>(closed_unit<std::int8_t>(.5)) == .5, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(closed_unit<std::int16_t>(.125f)) == .125f, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(closed_unit<std::int16_t>(.640625l)) == .640625, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(closed_unit<std::int16_t>(1)) == 1, "sg14::closed_unit test failed");
-static_assert(static_cast<double>(closed_unit<std::int8_t>(-.5)) == -.5, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(closed_unit<std::int16_t>(-.125f)) == -.125f, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(closed_unit<std::int16_t>(-.640625l)) == -.640625, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(closed_unit<std::int16_t>(-1)) == -1, "sg14::closed_unit test failed");
-
-// open_unit
-static_assert(static_cast<double>(open_unit<std::uint8_t>(.5)) == .5, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(open_unit<std::uint16_t>(.125f)) == .125f, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(open_unit<std::uint16_t>(.640625l)) == .640625, "sg14::closed_unit test failed");
-static_assert(static_cast<float>(open_unit<std::uint16_t>(1)) == 0, "sg14::closed_unit test failed");	// dropped bit
-
-static_assert(static_cast<double>(open_unit<std::int8_t>(.5)) == .5, "sg14::open_unit test failed");
-static_assert(static_cast<float>(open_unit<std::int16_t>(.125f)) == .125f, "sg14::open_unit test failed");
-static_assert(static_cast<float>(open_unit<std::int16_t>(.640625l)) == .640625, "sg14::open_unit test failed");
-static_assert(static_cast<float>(open_unit<std::int16_t>(1)) != 1, "sg14::open_unit test failed");	// dropped bit
-static_assert(static_cast<double>(open_unit<std::int8_t>(-.5)) == -.5, "sg14::open_unit test failed");
-static_assert(static_cast<float>(open_unit<std::int16_t>(-.125f)) == -.125f, "sg14::open_unit test failed");
-static_assert(static_cast<float>(open_unit<std::int16_t>(-.640625l)) == -.640625, "sg14::open_unit test failed");
-static_assert(static_cast<float>(open_unit<std::int16_t>(-1)) == -1, "sg14::open_unit test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // boolean
@@ -384,17 +351,17 @@ static_assert(! fixed_point<>(0), "sg14::fixed_point test failed");
 // arithmetic
 
 // addition
-static_assert(static_cast<int>((fixed31_0_t(123) + fixed31_0_t(123))) == 246, "sg14::fixed_point test failed");
-static_assert(static_cast<float>((fixed15_16_t(123.125) + fixed15_16_t(123.75))) == 246.875, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((make_fixed<31, 0>(123) + make_fixed<31, 0>(123))) == 246, "sg14::fixed_point test failed");
+static_assert(static_cast<float>((make_fixed<15, 16>(123.125) + make_fixed<15, 16>(123.75))) == 246.875, "sg14::fixed_point test failed");
 
 // subtraction
-static_assert(static_cast<int>((fixed31_0_t(999) - fixed31_0_t(369))) == 630, "sg14::fixed_point test failed");
-static_assert(static_cast<float>((fixed15_16_t(246.875) - fixed15_16_t(123.75))) == 123.125, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((make_fixed<31, 0>(999) - make_fixed<31, 0>(369))) == 630, "sg14::fixed_point test failed");
+static_assert(static_cast<float>((make_fixed<15, 16>(246.875) - make_fixed<15, 16>(123.75))) == 123.125, "sg14::fixed_point test failed");
 static_assert(static_cast<float>((fixed_point<std::int16_t, -4>(123.125) - fixed_point<std::int16_t, -4>(246.875))) == -123.75, "sg14::fixed_point test failed");
 
 // multiplication
-static_assert(static_cast<int>((ufixed8_0_t(0x55) * ufixed8_0_t(2))) == 0xaa, "sg14::fixed_point test failed");
-static_assert(static_cast<float>((fixed15_16_t(123.75) * fixed15_16_t(44.5))) == 5506.875, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((make_ufixed<8, 0>(0x55) * make_ufixed<8, 0>(2))) == 0xaa, "sg14::fixed_point test failed");
+static_assert(static_cast<float>((make_fixed<15, 16>(123.75) * make_fixed<15, 16>(44.5))) == 5506.875, "sg14::fixed_point test failed");
 #if defined(_SG14_FIXED_POINT_128)
 static_assert(static_cast<int>((fixed_point<std::uint64_t, -8>(1003006) * fixed_point<std::uint64_t, -8>(7))) == 7021042, "sg14::fixed_point test failed");
 #endif
@@ -402,7 +369,7 @@ static_assert(static_cast<int>((fixed_point<std::uint64_t, -8>(1003006) * fixed_
 // division
 static_assert(static_cast<float>((fixed_point<std::int8_t, -1>(63) / fixed_point<std::int8_t, -1>(-4))) == -15.5, "sg14::fixed_point test failed");
 static_assert(static_cast<int>((fixed_point<std::int8_t, 1>(-255) / fixed_point<std::int8_t, 1>(-8))) == 32, "sg14::fixed_point test failed");
-static_assert(static_cast<int>((fixed31_0_t(-999) / fixed31_0_t(3))) == -333, "sg14::fixed_point test failed");
+static_assert(static_cast<int>((make_fixed<31, 0>(-999) / make_fixed<31, 0>(3))) == -333, "sg14::fixed_point test failed");
 #if defined(_SG14_FIXED_POINT_128)
 static_assert(static_cast<int>((fixed_point<std::uint64_t, -8>(65535) / fixed_point<std::uint64_t, -8>(256))) == 255, "sg14::fixed_point test failed");
 #endif
@@ -420,17 +387,17 @@ static_assert(std::is_same<fixed_point<std::int8_t, -4>, fixed_point_demotion_t<
 static_assert(std::is_same<fixed_point<std::uint32_t, 44>, fixed_point_demotion_t<fixed_point<std::uint64_t, 88>>>::value, "sg14::fixed_point_demotion_t test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
-// sg14::make_fixed_from_repr
+// sg14::_impl::make_fixed_from_repr
 
-static_assert(make_fixed_from_repr<std::uint8_t, 8>::integer_digits == 8, "sg14::make_fixed_from_repr test failed");
-static_assert(make_fixed_from_repr<std::int32_t, 27>::integer_digits == 27, "sg14::make_fixed_from_repr test failed");
+static_assert(_impl::make_fixed_from_repr<std::uint8_t, 8>::integer_digits == 8, "sg14::_impl::make_fixed_from_repr test failed");
+static_assert(_impl::make_fixed_from_repr<std::int32_t, 27>::integer_digits == 27, "sg14::_impl::make_fixed_from_repr test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
-// sg14::make_fixed_from_pair
+// sg14::common_type
 
-static_assert(std::is_same<make_fixed_from_pair<fixed_point<std::uint8_t, -4>, fixed_point<std::int8_t, -4>>, fixed_point<int8_t, -3>>::value, "sg14::make_fixed_from_pair");
-static_assert(std::is_same<make_fixed_from_pair<fixed_point<std::int16_t, -4>, fixed_point<std::int32_t, -14>>, fixed_point<int32_t, -14>>::value, "sg14::make_fixed_from_pair");
-static_assert(std::is_same<make_fixed_from_pair<fixed_point<std::int16_t, 0>, fixed_point<std::uint64_t, -60>>, fixed_point<int64_t, -48>>::value, "sg14::make_fixed_from_pair");
+static_assert(std::is_same<common_type<fixed_point<std::uint8_t, -4>, fixed_point<std::int8_t, -4>>, fixed_point<int8_t, -3>>::value, "sg14::common_type");
+static_assert(std::is_same<common_type<fixed_point<std::int16_t, -4>, fixed_point<std::int32_t, -14>>, fixed_point<int32_t, -14>>::value, "sg14::common_type");
+static_assert(std::is_same<common_type<fixed_point<std::int16_t, 0>, fixed_point<std::uint64_t, -60>>, fixed_point<int64_t, -48>>::value, "sg14::common_type");
 
 ////////////////////////////////////////////////////////////////////////////////
 // comparison
@@ -467,15 +434,15 @@ static_assert(shift_multiply_result_t<fixed_point<std::uint8_t, 0>>::integer_dig
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::shift_multiply
 
-static_assert(static_cast<int>(shift_multiply(fixed7_8_t(127), fixed7_8_t(127))) == 16129, "sg14::shift_multiply test failed");
-static_assert(static_cast<int>(shift_multiply(ufixed4_4_t(15.9375), ufixed4_4_t(15.9375))) == 254, "sg14::shift_multiply test failed");
-static_assert(static_cast<float>(shift_multiply(ufixed4_4_t(0.0625), ufixed4_4_t(0.0625))) == 0, "sg14::shift_multiply test failed");
-static_assert(static_cast<float>(shift_multiply(ufixed8_0_t(1), ufixed8_0_t(1))) == 0, "sg14::shift_multiply test failed");
-static_assert(static_cast<float>(shift_multiply(ufixed8_0_t(174), ufixed8_0_t(25))) == 4096, "sg14::shift_multiply test failed");
+static_assert(static_cast<int>(shift_multiply(make_fixed<7, 8>(127), make_fixed<7, 8>(127))) == 16129, "sg14::shift_multiply test failed");
+static_assert(static_cast<int>(shift_multiply(make_ufixed<4, 4>(15.9375), make_ufixed<4, 4>(15.9375))) == 254, "sg14::shift_multiply test failed");
+static_assert(static_cast<float>(shift_multiply(make_ufixed<4, 4>(0.0625), make_ufixed<4, 4>(0.0625))) == 0, "sg14::shift_multiply test failed");
+static_assert(static_cast<float>(shift_multiply(make_ufixed<8, 0>(1), make_ufixed<8, 0>(1))) == 0, "sg14::shift_multiply test failed");
+static_assert(static_cast<float>(shift_multiply(make_ufixed<8, 0>(174), make_ufixed<8, 0>(25))) == 4096, "sg14::shift_multiply test failed");
 static_assert(static_cast<int>(shift_multiply(make_fixed<8, 0, false>(174), make_fixed<6, 2, false>(25))) == 4288, "sg14::shift_multiply test failed");
-static_assert(static_cast<double>(shift_multiply(fixed4_3_t(15.875), make_fixed<16, 0, false>(65535))) == 1040352, "sg14::shift_multiply test failed");
-static_assert(static_cast<int>(shift_multiply(fixed4_3_t(-16), fixed4_3_t(-15.875))) == 254, "sg14::shift_multiply test failed");
-static_assert(static_cast<int>(shift_multiply(fixed4_3_t(-16), fixed4_3_t(-16))) == -256, "sg14::shift_multiply test failed");
+static_assert(static_cast<double>(shift_multiply(make_fixed<4, 3>(15.875), make_fixed<16, 0, false>(65535))) == 1040352, "sg14::shift_multiply test failed");
+static_assert(static_cast<int>(shift_multiply(make_fixed<4, 3>(-16), make_fixed<4, 3>(-15.875))) == 254, "sg14::shift_multiply test failed");
+static_assert(static_cast<int>(shift_multiply(make_fixed<4, 3>(-16), make_fixed<4, 3>(-16))) == -256, "sg14::shift_multiply test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::shift_add_result_t
@@ -487,7 +454,7 @@ static_assert(shift_add_result_t<fixed_point<std::int32_t, -25>, 4>::integer_dig
 // sg14::shift_add
 
 static_assert(static_cast<int>(shift_add(fixed_point<std::uint8_t, -1>(127), fixed_point<std::uint8_t, -1>(127))) == 254, "sg14::shift_add test failed");
-static_assert(static_cast<float>(shift_add(ufixed4_4_t(15.5), ufixed4_4_t(14.25), ufixed4_4_t(13.5))) == 43.25, "sg14::shift_add test failed");
+static_assert(static_cast<float>(shift_add(make_ufixed<4, 4>(15.5), make_ufixed<4, 4>(14.25), make_ufixed<4, 4>(13.5))) == 43.25, "sg14::shift_add test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::shift_subtract_result_t
@@ -516,7 +483,7 @@ static_assert(std::is_same<shift_square_result_t<fixed_point<std::int32_t, -25>>
 // sg14::shift_square
 
 static_assert(static_cast<int>(shift_square(fixed_point<std::uint8_t, -1>(127))) == 16128, "sg14::shift_square test failed");
-static_assert(static_cast<float>(shift_square(ufixed4_4_t(15.5))) == 240, "sg14::shift_square test failed");
+static_assert(static_cast<float>(shift_square(make_ufixed<4, 4>(15.5))) == 240, "sg14::shift_square test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::shift_sqrt_result_t
@@ -528,220 +495,29 @@ static_assert(std::is_same<shift_sqrt_result_t<fixed_point<std::int32_t, -16>>, 
 // sg14::shift_sqrt
 
 static_assert(static_cast<int>(shift_sqrt(fixed_point<std::int16_t, -1>(16128))) == 126, "sg14::shift_sqrt test failed");
-static_assert(static_cast<float>(shift_sqrt(ufixed8_0_t(240))) == 15, "sg14::shift_sqrt test failed");
+static_assert(static_cast<float>(shift_sqrt(make_ufixed<8, 0>(240))) == 15, "sg14::shift_sqrt test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::abs
 
-static_assert(static_cast<int>(abs(fixed7_0_t(66))) == 66, "sg14::abs test failed");
-static_assert(static_cast<int>(abs(fixed7_0_t(-123))) == 123, "sg14::abs test failed");
-static_assert(static_cast<std::int64_t>(abs(fixed63_0_t(9223372036854775807))) == 9223372036854775807, "sg14::abs test failed");
-static_assert(static_cast<std::int64_t>(abs(fixed63_0_t(-9223372036854775807))) == 9223372036854775807, "sg14::abs test failed");
-static_assert(static_cast<int>(abs(fixed7_8_t(-5))) == 5, "sg14::abs test failed");
+static_assert(static_cast<int>(abs(make_fixed<7, 0>(66))) == 66, "sg14::abs test failed");
+static_assert(static_cast<int>(abs(make_fixed<7, 0>(-123))) == 123, "sg14::abs test failed");
+static_assert(static_cast<std::int64_t>(abs(make_fixed<63, 0>(9223372036854775807))) == 9223372036854775807, "sg14::abs test failed");
+static_assert(static_cast<std::int64_t>(abs(make_fixed<63, 0>(-9223372036854775807))) == 9223372036854775807, "sg14::abs test failed");
+static_assert(static_cast<int>(abs(make_fixed<7, 8>(-5))) == 5, "sg14::abs test failed");
 
 ////////////////////////////////////////////////////////////////////////////////
 // sg14::sqrt
 
-static_assert(static_cast<int>(sqrt(ufixed8_0_t(225))) == 15, "sg14::sqrt test failed");
-static_assert(static_cast<int>(sqrt(fixed7_0_t(81))) == 9, "sg14::sqrt test failed");
+static_assert(static_cast<int>(sqrt(make_ufixed<8, 0>(225))) == 15, "sg14::sqrt test failed");
+static_assert(static_cast<int>(sqrt(make_fixed<7, 0>(81))) == 9, "sg14::sqrt test failed");
 
 static_assert(static_cast<int>(sqrt(fixed_point<std::uint8_t, -1>(4))) == 2, "sg14::sqrt test failed");
 static_assert(static_cast<int>(sqrt(fixed_point<std::int8_t, -2>(9))) == 3, "sg14::sqrt test failed");
 
-static_assert(static_cast<int>(sqrt(ufixed4_4_t(4))) == 2, "sg14::sqrt test failed");
+static_assert(static_cast<int>(sqrt(make_ufixed<4, 4>(4))) == 2, "sg14::sqrt test failed");
 static_assert(static_cast<float>(sqrt(fixed_point<std::int32_t, -24>(3.141592654))) > 1.7724537849426, "sg14::sqrt test failed");
 static_assert(static_cast<float>(sqrt(fixed_point<std::int32_t, -24>(3.141592654))) < 1.7724537849427, "sg14::sqrt test failed");
 #if defined(_SG14_FIXED_POINT_128)
-static_assert(static_cast<std::int64_t>(sqrt(fixed63_0_t(9223372036854775807))) == 3037000499, "sg14::sqrt test failed");
-#endif
-
-////////////////////////////////////////////////////////////////////////////////
-// sg14::lerp
-
-static_assert(static_cast<float>(lerp(ufixed1_7_t(1), ufixed1_7_t(0), .5)) == .5f, "sg14::lerp test failed");
-static_assert(static_cast<float>(lerp(ufixed8_8_t(.125), ufixed8_8_t(.625), .5)) == .375f, "sg14::lerp test failed");
-static_assert(static_cast<unsigned>(lerp(ufixed16_16_t(42123.51323), ufixed16_16_t(432.9191), .812)) == 8270, "sg14::lerp test failed");
-
-static_assert(static_cast<float>(lerp(fixed_point<std::int8_t, -6>(1), fixed_point<std::int8_t, -6>(0), .5)) == .5f, "sg14::lerp test failed");
-static_assert(static_cast<float>(lerp(fixed_point<std::int16_t, -10>(.125), fixed_point<std::int16_t, -10>(.625), .5)) == .375f, "sg14::lerp test failed");
-static_assert(static_cast<float>(lerp(fixed_point<std::int32_t, -6>(.125), fixed_point<std::int32_t, -6>(.625), .25)) == .25f, "sg14::lerp test failed");
-
-////////////////////////////////////////////////////////////////////////////////
-// fixed_point specializations
-
-// integer_digits
-static_assert(fixed0_7_t::integer_digits == 0, "fixed_point specializations test failed");
-static_assert(fixed1_6_t::integer_digits == 1, "fixed_point specializations test failed");
-static_assert(fixed3_4_t::integer_digits == 3, "fixed_point specializations test failed");
-static_assert(fixed4_3_t::integer_digits == 4, "fixed_point specializations test failed");
-static_assert(fixed7_0_t::integer_digits == 7, "fixed_point specializations test failed");
-
-static_assert(ufixed0_8_t::integer_digits == 0, "fixed_point specializations test failed");
-static_assert(ufixed1_7_t::integer_digits == 1, "fixed_point specializations test failed");
-static_assert(ufixed4_4_t::integer_digits == 4, "fixed_point specializations test failed");
-static_assert(ufixed8_0_t::integer_digits == 8, "fixed_point specializations test failed");
-
-static_assert(fixed0_15_t::integer_digits == 0, "fixed_point specializations test failed");
-static_assert(fixed1_14_t::integer_digits == 1, "fixed_point specializations test failed");
-static_assert(fixed7_8_t::integer_digits == 7, "fixed_point specializations test failed");
-static_assert(fixed8_7_t::integer_digits == 8, "fixed_point specializations test failed");
-static_assert(fixed15_0_t::integer_digits == 15, "fixed_point specializations test failed");
-
-static_assert(ufixed0_16_t::integer_digits == 0, "fixed_point specializations test failed");
-static_assert(ufixed1_15_t::integer_digits == 1, "fixed_point specializations test failed");
-static_assert(ufixed8_8_t::integer_digits == 8, "fixed_point specializations test failed");
-static_assert(ufixed16_0_t::integer_digits == 16, "fixed_point specializations test failed");
-
-static_assert(fixed0_31_t::integer_digits == 0, "fixed_point specializations test failed");
-static_assert(fixed1_30_t::integer_digits == 1, "fixed_point specializations test failed");
-static_assert(fixed15_16_t::integer_digits == 15, "fixed_point specializations test failed");
-static_assert(fixed16_15_t::integer_digits == 16, "fixed_point specializations test failed");
-static_assert(fixed31_0_t::integer_digits == 31, "fixed_point specializations test failed");
-
-static_assert(ufixed0_32_t::integer_digits == 0, "fixed_point specializations test failed");
-static_assert(ufixed1_31_t::integer_digits == 1, "fixed_point specializations test failed");
-static_assert(ufixed16_16_t::integer_digits == 16, "fixed_point specializations test failed");
-static_assert(ufixed32_0_t::integer_digits == 32, "fixed_point specializations test failed");
-
-static_assert(fixed0_63_t::integer_digits == 0, "fixed_point specializations test failed");
-static_assert(fixed1_62_t::integer_digits == 1, "fixed_point specializations test failed");
-static_assert(fixed31_32_t::integer_digits == 31, "fixed_point specializations test failed");
-static_assert(fixed32_31_t::integer_digits == 32, "fixed_point specializations test failed");
-static_assert(fixed63_0_t::integer_digits == 63, "fixed_point specializations test failed");
-
-static_assert(ufixed0_64_t::integer_digits == 0, "fixed_point specializations test failed");
-static_assert(ufixed1_63_t::integer_digits == 1, "fixed_point specializations test failed");
-static_assert(ufixed32_32_t::integer_digits == 32, "fixed_point specializations test failed");
-static_assert(ufixed64_0_t::integer_digits == 64, "fixed_point specializations test failed");
-
-#if defined(_SG14_FIXED_POINT_128)
-static_assert(fixed0_127_t::integer_digits == 0, "fixed_point specializations test failed");
-static_assert(fixed1_126_t::integer_digits == 1, "fixed_point specializations test failed");
-static_assert(fixed63_64_t::integer_digits == 63, "fixed_point specializations test failed");
-static_assert(fixed64_63_t::integer_digits == 64, "fixed_point specializations test failed");
-static_assert(fixed127_0_t::integer_digits == 127, "fixed_point specializations test failed");
-
-static_assert(ufixed0_128_t::integer_digits == 0, "fixed_point specializations test failed");
-static_assert(ufixed1_127_t::integer_digits == 1, "fixed_point specializations test failed");
-static_assert(ufixed64_64_t::integer_digits == 64, "fixed_point specializations test failed");
-static_assert(ufixed128_0_t::integer_digits == 128, "fixed_point specializations test failed");
-#endif
-
-// fractional_digits
-static_assert(fixed0_7_t::fractional_digits == 7, "fixed_point specializations test failed");
-static_assert(fixed1_6_t::fractional_digits == 6, "fixed_point specializations test failed");
-static_assert(fixed3_4_t::fractional_digits == 4, "fixed_point specializations test failed");
-static_assert(fixed4_3_t::fractional_digits == 3, "fixed_point specializations test failed");
-static_assert(fixed7_0_t::fractional_digits == 0, "fixed_point specializations test failed");
-
-static_assert(ufixed0_8_t::fractional_digits == 8, "fixed_point specializations test failed");
-static_assert(ufixed1_7_t::fractional_digits == 7, "fixed_point specializations test failed");
-static_assert(ufixed4_4_t::fractional_digits == 4, "fixed_point specializations test failed");
-static_assert(ufixed8_0_t::fractional_digits == 0, "fixed_point specializations test failed");
-
-static_assert(fixed0_15_t::fractional_digits == 15, "fixed_point specializations test failed");
-static_assert(fixed1_14_t::fractional_digits == 14, "fixed_point specializations test failed");
-static_assert(fixed7_8_t::fractional_digits == 8, "fixed_point specializations test failed");
-static_assert(fixed8_7_t::fractional_digits == 7, "fixed_point specializations test failed");
-static_assert(fixed15_0_t::fractional_digits == 0, "fixed_point specializations test failed");
-
-static_assert(ufixed0_16_t::fractional_digits == 16, "fixed_point specializations test failed");
-static_assert(ufixed1_15_t::fractional_digits == 15, "fixed_point specializations test failed");
-static_assert(ufixed8_8_t::fractional_digits == 8, "fixed_point specializations test failed");
-static_assert(ufixed16_0_t::fractional_digits == 0, "fixed_point specializations test failed");
-
-static_assert(fixed0_31_t::fractional_digits == 31, "fixed_point specializations test failed");
-static_assert(fixed1_30_t::fractional_digits == 30, "fixed_point specializations test failed");
-static_assert(fixed15_16_t::fractional_digits == 16, "fixed_point specializations test failed");
-static_assert(fixed16_15_t::fractional_digits == 15, "fixed_point specializations test failed");
-static_assert(fixed31_0_t::fractional_digits == 0, "fixed_point specializations test failed");
-
-static_assert(ufixed0_32_t::fractional_digits == 32, "fixed_point specializations test failed");
-static_assert(ufixed1_31_t::fractional_digits == 31, "fixed_point specializations test failed");
-static_assert(ufixed16_16_t::fractional_digits == 16, "fixed_point specializations test failed");
-static_assert(ufixed32_0_t::fractional_digits == 0, "fixed_point specializations test failed");
-
-static_assert(fixed0_63_t::fractional_digits == 63, "fixed_point specializations test failed");
-static_assert(fixed1_62_t::fractional_digits == 62, "fixed_point specializations test failed");
-static_assert(fixed31_32_t::fractional_digits == 32, "fixed_point specializations test failed");
-static_assert(fixed32_31_t::fractional_digits == 31, "fixed_point specializations test failed");
-static_assert(fixed63_0_t::fractional_digits == 0, "fixed_point specializations test failed");
-
-static_assert(ufixed0_64_t::fractional_digits == 64, "fixed_point specializations test failed");
-static_assert(ufixed1_63_t::fractional_digits == 63, "fixed_point specializations test failed");
-static_assert(ufixed32_32_t::fractional_digits == 32, "fixed_point specializations test failed");
-static_assert(ufixed64_0_t::fractional_digits == 0, "fixed_point specializations test failed");
-
-#if defined(_SG14_FIXED_POINT_128)
-static_assert(fixed0_127_t::fractional_digits == 127, "fixed_point specializations test failed");
-static_assert(fixed1_126_t::fractional_digits == 126, "fixed_point specializations test failed");
-static_assert(fixed63_64_t::fractional_digits == 64, "fixed_point specializations test failed");
-static_assert(fixed64_63_t::fractional_digits == 63, "fixed_point specializations test failed");
-static_assert(fixed127_0_t::fractional_digits == 0, "fixed_point specializations test failed");
-
-static_assert(ufixed0_128_t::fractional_digits == 128, "fixed_point specializations test failed");
-static_assert(ufixed1_127_t::fractional_digits == 127, "fixed_point specializations test failed");
-static_assert(ufixed64_64_t::fractional_digits == 64, "fixed_point specializations test failed");
-static_assert(ufixed128_0_t::fractional_digits == 0, "fixed_point specializations test failed");
-#endif
-
-////////////////////////////////////////////////////////////////////////////////
-// sg14::make_fixed
-
-// integer_digits
-static_assert(std::is_same<make_fixed<0, 7, true>, fixed0_7_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<1, 6, true>, fixed1_6_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<3, 4, true>, fixed3_4_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<4, 3, true>, fixed4_3_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<7, 0, true>, fixed7_0_t>::value, "make_fixed specializations test failed");
-
-static_assert(std::is_same<make_fixed<0, 8, false>, ufixed0_8_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<1, 7, false>, ufixed1_7_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<4, 4, false>, ufixed4_4_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<8, 0, false>, ufixed8_0_t>::value, "make_fixed specializations test failed");
-
-static_assert(std::is_same<make_fixed<0, 15, true>, fixed0_15_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<1, 14, true>, fixed1_14_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<7, 8, true>, fixed7_8_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<8, 7, true>, fixed8_7_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<15, 0, true>, fixed15_0_t>::value, "make_fixed specializations test failed");
-
-static_assert(std::is_same<make_fixed<0, 16, false>, ufixed0_16_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<1, 15, false>, ufixed1_15_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<8, 8, false>, ufixed8_8_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<16, 0, false>, ufixed16_0_t>::value, "make_fixed specializations test failed");
-
-static_assert(std::is_same<make_fixed<0, 31, true>, fixed0_31_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<1, 30, true>, fixed1_30_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<15, 16, true>, fixed15_16_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<16, 15, true>, fixed16_15_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<31, 0, true>, fixed31_0_t>::value, "make_fixed specializations test failed");
-
-static_assert(std::is_same<make_fixed<0, 32, false>, ufixed0_32_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<1, 31, false>, ufixed1_31_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<16, 16, false>, ufixed16_16_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<32, 0, false>, ufixed32_0_t>::value, "make_fixed specializations test failed");
-
-static_assert(std::is_same<make_fixed<0, 63, true>, fixed0_63_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<1, 62, true>, fixed1_62_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<31, 32, true>, fixed31_32_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<32, 31, true>, fixed32_31_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<63, 0, true>, fixed63_0_t>::value, "make_fixed specializations test failed");
-
-static_assert(std::is_same<make_fixed<0, 64, false>, ufixed0_64_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<1, 63, false>, ufixed1_63_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<32, 32, false>, ufixed32_32_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<64, 0, false>, ufixed64_0_t>::value, "make_fixed specializations test failed");
-
-#if defined(_SG14_FIXED_POINT_128)
-static_assert(std::is_same<make_fixed<0, 127, true>, fixed0_127_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<1, 126, true>, fixed1_126_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<63, 64, true>, fixed63_64_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<64, 63, true>, fixed64_63_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<127, 0, true>, fixed127_0_t>::value, "make_fixed specializations test failed");
-
-static_assert(std::is_same<make_fixed<0, 128, false>, ufixed0_128_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<1, 127, false>, ufixed1_127_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<64, 64, false>, ufixed64_64_t>::value, "make_fixed specializations test failed");
-static_assert(std::is_same<make_fixed<128, 0, false>, ufixed128_0_t>::value, "make_fixed specializations test failed");
+static_assert(static_cast<std::int64_t>(sqrt(make_fixed<63, 0>(9223372036854775807))) == 3037000499, "sg14::sqrt test failed");
 #endif


### PR DESCRIPTION
- fixed_point specializations removed
- make_fixed and make_ufixed are now preferred way of making types
- make_fixed_from_repr consigned to _impl namespace
- make_fixed_from_pair renamed to common_type
- closed_unit, open_unit and lerp removed