### PR TITLE
Fix compilation errors

### DIFF
--- a/SG14/ring.h
+++ b/SG14/ring.h
@@ -49,7 +49,7 @@ namespace sg14
 		{
 		}
 	
-		static_ring(container_type&&) noexcept(std::is_nothrow_move_constructible<T>::value)
+		static_ring(container_type&& rhs) noexcept(std::is_nothrow_move_constructible<T>::value)
 			: c(std::move(rhs))
 			, count(0)
 			, next_element(std::begin(c))

--- a/SG14_test/uninitialized.cpp
+++ b/SG14_test/uninitialized.cpp
@@ -34,12 +34,21 @@ namespace
 			move = 0;
 		}
 
-		static void test(uint64_t inconstruct, uint64_t indestruct, uint64_t inmove)
-		{
-			assert(construct == inconstruct);
-			assert(destruct == indestruct);
-			assert(move == inmove);
-		}
+		// To avoid "unused argument" error/warning. 
+		#ifdef NDEBUG
+			static void test(uint64_t, uint64_t, uint64_t)
+			{
+				
+			}
+		#else
+			static void test(uint64_t inconstruct, uint64_t indestruct, uint64_t inmove)
+			{
+				assert(construct == inconstruct);
+				assert(destruct == indestruct);
+				assert(move == inmove);
+			}
+		#endif
+		
 	};
 	uint64_t lifetest::construct;
 	uint64_t lifetest::destruct;

--- a/SG14_test/unstable_remove_test.cpp
+++ b/SG14_test/unstable_remove_test.cpp
@@ -4,7 +4,7 @@
 #include <ctime>
 #include <iostream>
 #include <algorithm>
-#include "algorithm_ext.h"
+#include "../SG14/algorithm_ext.h"
 #include <cassert>
 #include <memory>
 #include <chrono>
@@ -23,7 +23,6 @@ struct foo
 
 void sg14_test::unstable_remove_test()
 {
-#if 0
 	size_t test_runs = 200;
 
 	auto makelist = []
@@ -71,7 +70,7 @@ void sg14_test::unstable_remove_test()
 	unstable_remove_if.reserve(test_runs);
 	remove_if.reserve(test_runs);
 
-	for (int i = 0; i < test_runs; ++i)
+	for (decltype(test_runs) i = 0; i < test_runs; ++i)
 	{
 		remove_if.push_back(time(removefn));
 		unstable_remove_if.push_back(time(unstablefn));
@@ -90,5 +89,4 @@ void sg14_test::unstable_remove_test()
 	std::cout << "unstable: " << unstable_med << "\n";
 	std::cout << "remove_if: " << remove_med << "\n";
 	std::cin.get();
-#endif
 }

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -3,7 +3,7 @@ project(sg14)
 
 set(WARNING_FLAGS "-Wall -Wextra -Wfatal-errors -Werror")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS} -std=c++14")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG -fno-rtti -Ofast")
 set(CMAKE_EXE_LINKER_FLAGS "-g")


### PR DESCRIPTION
* C*+14 is required for the unstable_remove test
* Since -Werror is being used, unsigned and signed types have to match in comparisons
* Since -Werror is being used, unused parameters due to asserts fail to compile
* `rhs` was missing (typo) from ring.h