### PR TITLE
2015-10-4: v2.21

### DIFF
--- a/Docs/plf_licensing.txt
+++ b/Docs/plf_licensing.txt
@@ -1,5 +1,4 @@
-Copyright (c) 2015 Matthew Bentley
-All plf:: modules are provided under a zlib license.
+All plf:: modules are provided under a zlib license:
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages
@@ -17,3 +16,4 @@ freely, subject to the following restrictions:
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
 
+Copyright (c) 2015 Matthew Bentley

--- a/Docs/plf_readme.txt
+++ b/Docs/plf_readme.txt
@@ -1,4 +1,4 @@
-Full Documentation: http://www.plflib.org
+Full Documentation: www.plflib.org
 
 
 plf::colony
@@ -6,16 +6,16 @@ plf::colony
 
 What is a colony? It's similar to a vector or a deque, but substantially different.
 
-Vector's constant reallocation equals constant iterator/pointer invalidation, which means inability for objects in vectors to reference each other. There are workarounds for this (in given situations - not all situations), but each of them is a hack around vector's limitations, which slows down program speed and development time.
+Vector and deque's reallocations equal iterator/pointer invalidation, which means inability for objects in vectors to reference each other. There are workarounds for this (in given situations - not all situations), but each of them is a hack around vector's limitations, which slows down program speed and development time.
 
 Compared to other STL container types, Vectors have better cache coherency and hence better speed regardless of the situation (See Chandler Carruth's talk here: http://www.youtube.com/watch?v=fHNmRkzxHWs). But erasing from anywhere but the end of a vector is painfully slow, and adding/pushing/popping to/from a vector - for large objects - is not as fast we'd like.
 
 Colonies don't reallocate - they form chains of increasingly-large blocks of elements, resulting in a fast container which never invalidates pointers or iterators, generally has twice the add-speed of vectors, virtually no performance penalty for erasing elements, and similar iteration speed for larger-than-scalar types (usually better than vector on an x86 test machine, worse than vector on an x64 test machine).
 
-plf::stack, which plf::colony uses internally, is built on the same principle - pointers to elements will never invalidate, and it is overall faster than a std::stack.
+plf::stack, which plf::colony uses internally, is based on the same principle - pointers/references to non-erased elements never invalidate and it is overall faster than a std::stack.
 
+Run the plf_demo.cpp for an overview of performance characteristics.
 
-
-PLEASE SEE WEBSITE FOR FULL FUNCTION DETAILS, AND THE LICENSING.TXT FILE FOR APPROPRIATE USAGE AND LEGALITIES.
-Contact me with bugs at: mattreecebentley@gmail.com
-plf:: library Copyright (c) 2015 Matt Bentley
+SEE WEBSITE FOR FULL DOCUMENTATION AND LICENSING.TXT FOR APPROPRIATE USAGE AND LEGALITIES.
+Contact me with bugs etc at: mattreecebentley@gmail.com
+plf::stack and plf::colony Copyright (c) 2015 Matt Bentley

--- a/Docs/plflib documentation - local cached copy - may become out of date/colony.htm
+++ b/Docs/plflib documentation - local cached copy - may become out of date/colony.htm
@@ -29,15 +29,15 @@ invalidation and with better performance for larger-than-scalar types (ie.
 structs, classes etc). Instead of using one single block of memory and
 reallocating, it utilises chains of increasingly-larger memory blocks to form a
 cache-contiguous container. Performance is better than std::vector in terms of
-adding elements, iteration can be slower or faster than std::vector, depending
-on compiler, size of data-type stored and platform it is running on, but in
-terms of element deletion colonies are many powers of 10 faster. Using a
+inserting elements, iteration can be slower or faster than std::vector,
+depending on compiler, size of data-type stored and platform it is running on,
+but in terms of element deletion colonies are many powers of 10 faster. Using a
 boolean field to indicate element deletion, instead of relocating data, the
 increasingly large erase times that we typically see with vectors as the data
 scale becomes higher are non-existent. A brief visual summary of the
 differences between vector allocation and colony allocation follows.</p>
 
-<h3>Adding to a full vector/colony</h3>
+<h3>Inserting into a full vector/colony</h3>
 <img src="vector_addition.gif"
 alt="Visual demonstration of adding to a full vector" height="540" width="960">
 <img src="colony_addition.gif"
@@ -51,7 +51,7 @@ alt="Visual demonstration of randomly erasing from a colony" height="540"
 width="960"> 
 
 <p>Colonies are best suited for collections of data where order is not
-important. Using the add function, new elements may be put in recycled (ie
+important. Using the insert function, new elements may be put in recycled (ie
 previously erased) element slots, but otherwise it pushes the data to the back
 of the colony much like a vector would. Random placement insertion in colonies
 is not possible due to the memory model. Having said all that, using a sort
@@ -64,7 +64,7 @@ shown in "release" compilation mode ie. -O2 on most compilers - there has been
 less optimisation done for debug mode (-O0). The larger the object being store
 in the colony is, the greater the speed advantage over vectors tends to be. For
 primitive datatypes eg. int's, vectors tend to have an advantage over colonies
-in terms of iteration, but not in terms of adding or deleting elements to the
+in terms of iteration, but not in terms of inserting or erasing elements to the
 container.</p>
 
 <h2><a id="license"></a>License</h2>
@@ -84,15 +84,35 @@ restrictions:</p>
 
 <h2><a id="download"></a>Download</h2>
 
-<p>Download <a href="plf_colony_2-9-2015.zip">here</a>. (19kb)<br>
+<p>Download <a href="plf_colony_4-10-2015.zip">here</a>. (20kb)<br>
 The colony library is a simple .h header file, to be included with a #include
 command. The package includes the plf::stack .h file, which is used internally
 by plf::colony.</p>
 
 <h3>Version history</h3>
 <ul>
+  <li>2015-10-4: v2.21 - Improved gcc x64 iteration. std::find now working with
+    reverse_iterator. reverse_iterator function corrections, performance
+    improvements. Hintless allocators under C++11 now supported. Allocation now
+    uses allocator_traits under C++11.</li>
+  <li>2015-9-30: v2.13 - Fixed performance regression with small scalar types
+    and MS VCC. Small bugfixes. Return type for iterator +/- iterator changed
+    to long long int. Small performance things.</li>
+  <li>2015-9-28: v2.12 - Added const_iterator, const_reverse_iterator, .cbegin,
+    .cend, .crbegin, .crend. Some small bugfixes.</li>
+  <li>2015-9-27: v2.00 - Larger performance improvements, particularly for
+    small scalar type storage. Corrections to exception handling and EBCO.
+    ".insert" replaces ".add" (realised there is precedence for
+    non-position-based insert via unordered_map/unordered_set). Added postfix
+    iterator increment and decrement. Zero-argument ".add()" and ".push()"
+    function overloads removed (same thing achievable with
+    "colony.insert(the_type());" and "stack.push(the_type());". Many bugfixes
+    and general code cleanup.</li>
+  <li>2015-9-15: v1.79 - Empty base class allocator optimisations and smaller
+    optimisation.</li>
   <li>2015-9-1: v1.77 - Some small bugfixes.</li>
-  <li>2015-8-30: v1.76 - Now exception-safe. Also fixed C++0x regression bug.</li>
+  <li>2015-8-30: v1.76 - Now exception-safe. Also fixed C++0x regression
+  bug.</li>
   <li>2015-8-22: v1.75 - Iterators more compliant and now work with std::find
     and should work with other std:: algorithm functions. Native find functions
     removed. (iterator - iterator) and (iterator + iterator) support added
@@ -151,7 +171,7 @@ by plf::colony.</p>
 
 <h2><a id="benchmarks"></a>Benchmarks</h2>
 
-<p style="font-size: 75%"><i>Last updated 13-7-2015 v1.70</i></p>
+<p style="font-size: 75%"><i>Last updated 5-10-2015 v2.20</i></p>
 
 <p>All of the benchmarks below are included in the plf_demo.cpp in the
 download, anyone can run them. They do not require any external libraries.</p>
@@ -160,17 +180,17 @@ download, anyone can run them. They do not require any external libraries.</p>
 the same for other x64 platforms. Compilers are mingw TDM GCC 5.1 (32-bit and
 64-bit versions), MS VC++ 2010 and MS VC++ 2013. I've ignored clang as the
 results were much the same as GCC. Release compilation settings only, no debug
-mode. Normal release settings for MS compilers, -O2;-march=native;-std=c++11
-for GCC. <a href="http://www.libsdl.org">SDL</a> was used for more precise
-timing.</p>
+mode. Release settings for MS compilers: "/O2 /Oi /Ot /Oy /GL /GS- /GY-
+/arch:SSE2 /MT". Release settings for GCC: "-O2 -march=native -std=c++11". <a
+href="http://www.libsdl.org">SDL</a> was used for more precise timing.</p>
 
 <h3>Real-world Object-Oriented tests</h3>
 
-<h4>Test one: Full add/erase, no invalidation</h4>
+<h4>Test one: Full insert/erase, no invalidation</h4>
 
 <p>Colony was formulated primarily for the situation where we:</p>
 <ol type="1">
-  <li>wish to be able to dynamically add to a container</li>
+  <li>wish to be able to insert to a container "on the fly"</li>
   <li>wish to be able to erase container elements</li>
   <li>do not wish to have any pointer/iterator invalidation, so that references
     between objects in containers remain valid</li>
@@ -181,12 +201,12 @@ vector/deque of pointers to dynamically-allocated objects. Because the object
 itself does not get moved when the vector/deque reallocates (only the pointer),
 references between objects stay consistent regardless of what happens in the
 vector/deque. Unfortunately as we shall see, the performance of this technique
-is less than grand. In addition in the test below I have included comparisons
+is less than grand. In addition, in the test below I have included comparisons
 with std::list and std::map, both of which satisfy the requirements above.</p>
 
 <table style="width: 100%" border="1">
-  <caption>Adding 2000000 small structs, each with a random unsigned int as one
-  of the members</caption>
+  <caption>Inserting 2000000 small structs, each with a random unsigned int as
+  one of the members</caption>
   <colgroup><col>
     <col>
     <col>
@@ -205,56 +225,56 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
     </tr>
     <tr>
       <td>std::vector (of pointers to dynamically-allocated objects)</td>
-      <td>178</td>
-      <td>171</td>
-      <td>211</td>
-      <td>205</td>
+      <td>176</td>
+      <td>174</td>
+      <td>194</td>
+      <td>195</td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>47</td>
-      <td>50</td>
-      <td>82</td>
-      <td>67<br>
+      <td>54</td>
+      <td>48</td>
+      <td>76</td>
+      <td>66<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::list</td>
-      <td>188</td>
-      <td>187</td>
-      <td>210</td>
-      <td>201<br>
+      <td>186</td>
+      <td>189</td>
+      <td>193</td>
+      <td>195<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::map</td>
-      <td>371</td>
-      <td>382</td>
-      <td>464</td>
-      <td>413<br>
+      <td>383</td>
+      <td>379</td>
+      <td>444</td>
+      <td>408<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque (of pointers to dynamically-allocated objects)</td>
-      <td>174</td>
-      <td>164</td>
-      <td>230</td>
-      <td>239<br>
+      <td>173</td>
+      <td>167</td>
+      <td>216</td>
+      <td>237<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>3.8x</td>
-      <td>3.4x</td>
+      <td>3.3x</td>
+      <td>3.6x</td>
       <td>2.6x</td>
-      <td>3.1x<br>
+      <td>3.0x<br>
       </td>
-      <td>3.2x<br>
+      <td>3.1x<br>
       </td>
     </tr>
   </tbody>
@@ -280,57 +300,57 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
     </tr>
     <tr>
       <td>std::vector (as above)</td>
-      <td>322</td>
-      <td>1029</td>
-      <td>328</td>
-      <td>1038<br>
+      <td>318</td>
+      <td>1041</td>
+      <td>334</td>
+      <td>1047<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>30</td>
-      <td>28</td>
-      <td>37</td>
+      <td>32</td>
+      <td>25</td>
+      <td>40</td>
       <td>29<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::list</td>
+      <td>30</td>
       <td>31</td>
-      <td>32</td>
-      <td>40</td>
-      <td>37<br>
+      <td>43</td>
+      <td>36<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::map</td>
-      <td>98</td>
-      <td>96</td>
-      <td>104</td>
-      <td>106<br>
+      <td>93</td>
+      <td>103</td>
+      <td>92</td>
+      <td>93<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque (as above)</td>
       <td>173</td>
-      <td>329</td>
-      <td>918</td>
-      <td>1494<br>
+      <td>336</td>
+      <td>929</td>
+      <td>1519<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>10.7x</td>
-      <td>36.8x</td>
-      <td>8.9x</td>
-      <td>35.8x<br>
+      <td>9.9x</td>
+      <td>41.6x</td>
+      <td>8.4x</td>
+      <td>36.1x<br>
       </td>
-      <td>23.1x<br>
+      <td>24.0x<br>
       </td>
     </tr>
   </tbody>
@@ -356,56 +376,56 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
     </tr>
     <tr>
       <td>std::vector (as above)</td>
-      <td>1568</td>
-      <td>2101</td>
-      <td>1527</td>
-      <td>2097<br>
+      <td>1579</td>
+      <td>2099</td>
+      <td>1520</td>
+      <td>2103<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>1146</td>
-      <td>1477</td>
-      <td>1157</td>
-      <td>1481<br>
+      <td>1158</td>
+      <td>1446</td>
+      <td>1204</td>
+      <td>1492<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::list</td>
-      <td>1946</td>
-      <td>2820</td>
-      <td>1960</td>
-      <td>2831<br>
+      <td>1953</td>
+      <td>2824</td>
+      <td>1961</td>
+      <td>2851<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::map</td>
-      <td>5311</td>
-      <td>5958</td>
-      <td>5437</td>
-      <td>6005<br>
+      <td>5564</td>
+      <td>6348</td>
+      <td>5521</td>
+      <td>6186<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque (as above)</td>
-      <td>1609</td>
-      <td>2121</td>
-      <td>1732</td>
-      <td>2498<br>
+      <td>1615</td>
+      <td>2109</td>
+      <td>1724</td>
+      <td>2509<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>1.37x</td>
-      <td>1.42x</td>
-      <td>1.32x</td>
-      <td>1.42x</td>
-      <td>1.38x<br>
+      <td>1.4x</td>
+      <td>1.5x</td>
+      <td>1.3x</td>
+      <td>1.4x</td>
+      <td>1.4x<br>
       </td>
     </tr>
   </tbody>
@@ -430,17 +450,17 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
     </tr>
     <tr>
       <td>std::vector (as above)</td>
-      <td>79</td>
-      <td>51</td>
-      <td>65</td>
-      <td>52<br>
+      <td>80</td>
+      <td>52</td>
+      <td>63</td>
+      <td>53<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
       <td>5</td>
-      <td>5</td>
+      <td>6</td>
       <td>5</td>
       <td>6</td>
       <td></td>
@@ -448,38 +468,38 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
     <tr>
       <td>std::list</td>
       <td>101</td>
-      <td>84</td>
-      <td>91</td>
-      <td>87<br>
+      <td>86</td>
+      <td>92</td>
+      <td>88<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::map</td>
-      <td>138</td>
-      <td>140</td>
-      <td>139</td>
-      <td>163<br>
+      <td>137</td>
+      <td>141</td>
+      <td>145</td>
+      <td>153<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque (as above)</td>
       <td>100</td>
-      <td>81</td>
-      <td>115</td>
-      <td>123<br>
+      <td>89</td>
+      <td>117</td>
+      <td>125<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>15.8x</td>
-      <td>10.2x</td>
-      <td>13.0x</td>
-      <td>8.7x<br>
+      <td>16.0x</td>
+      <td>8.7x</td>
+      <td>12.6x</td>
+      <td>8.8x<br>
       </td>
-      <td>11.9x<br>
+      <td>11.5x<br>
       </td>
     </tr>
   </tbody>
@@ -490,7 +510,7 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
 <p>We can see from this that under these circumstances, a colony outperforms
 all contenders, in every area.</p>
 
-<h4>Test two: Pre-execution Add, Full erase, no invalidation</h4>
+<h4>Test two: Pre-execution insert, Full erase, no invalidation</h4>
 
 <p>While the above test addresses the primary purpose of colonies, it is also
 useful to note there is a second commonly-used scenario - particularly in the
@@ -511,8 +531,8 @@ erasure. Neither the array nor the vector has the ability to free up memory or
 destruct objects during this process.</p>
 
 <table style="width: 100%" border="1">
-  <caption>Adding 5000000 small structs, each with a random unsigned int as one
-  of the members</caption>
+  <caption>Inserting 5000000 small structs, each with a random unsigned int as
+  one of the members</caption>
   <colgroup><col>
     <col>
     <col>
@@ -532,42 +552,42 @@ destruct objects during this process.</p>
     <tr>
       <td>std::vector</td>
       <td>331</td>
-      <td>300</td>
-      <td>453</td>
-      <td>505</td>
+      <td>310</td>
+      <td>432</td>
+      <td>497</td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>118</td>
-      <td>116</td>
-      <td>210</td>
-      <td>167</td>
+      <td>132</td>
+      <td>123</td>
+      <td>189</td>
+      <td>164</td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>124</td>
-      <td>110</td>
-      <td>157</td>
-      <td>136</td>
+      <td>128</td>
+      <td>115</td>
+      <td>134</td>
+      <td>121</td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque</td>
-      <td>169</td>
-      <td>166</td>
-      <td>543</td>
-      <td>528</td>
+      <td>172</td>
+      <td>168</td>
+      <td>522</td>
+      <td>504</td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>2.8x</td>
-      <td>2.6x</td>
-      <td>2.2x</td>
+      <td>2.5x</td>
+      <td>2.5x</td>
+      <td>2.3x</td>
       <td>3.0x</td>
-      <td>2.7x</td>
+      <td>2.6x</td>
     </tr>
   </tbody>
 </table>
@@ -592,48 +612,48 @@ destruct objects during this process.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>67</td>
-      <td>61</td>
-      <td>90</td>
-      <td>69<br>
+      <td>65</td>
+      <td>55</td>
+      <td>98</td>
+      <td>68<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>77</td>
-      <td>69</td>
-      <td>101</td>
-      <td>79<br>
+      <td>80</td>
+      <td>72</td>
+      <td>106</td>
+      <td>77<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>68</td>
-      <td>61</td>
-      <td>89</td>
-      <td>70<br>
+      <td>67</td>
+      <td>54</td>
+      <td>99</td>
+      <td>67<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque</td>
       <td>68</td>
-      <td>63</td>
-      <td>97</td>
+      <td>58</td>
+      <td>106</td>
       <td>74<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>0.89x</td>
-      <td>0.88x</td>
-      <td>0.89x</td>
-      <td>0.87x<br>
-      </td>
+      <td>0.81x</td>
+      <td>0.76x</td>
+      <td>0.92x</td>
       <td>0.88x<br>
+      </td>
+      <td>0.84x<br>
       </td>
     </tr>
   </tbody>
@@ -659,48 +679,48 @@ destruct objects during this process.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>2773</td>
-      <td>3520</td>
-      <td>2864</td>
-      <td>3579<br>
+      <td>2755</td>
+      <td>3540</td>
+      <td>2885</td>
+      <td>3554<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>2926</td>
-      <td>3707</td>
-      <td>3068</td>
-      <td>3773<br>
+      <td>2905</td>
+      <td>3646</td>
+      <td>3059</td>
+      <td>3698<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>2771</td>
-      <td>3490</td>
-      <td>2861</td>
-      <td>3537<br>
+      <td>2749</td>
+      <td>3518</td>
+      <td>2914</td>
+      <td>3488<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque</td>
-      <td>2925</td>
-      <td>3807</td>
-      <td>4235</td>
-      <td>5432<br>
+      <td>2907</td>
+      <td>3823</td>
+      <td>4302</td>
+      <td>5404<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
       <td>0.95x</td>
-      <td>0.95x</td>
-      <td>0.93x</td>
-      <td>0.95x<br>
+      <td>0.97x</td>
+      <td>0.94x</td>
+      <td>0.96x<br>
       </td>
-      <td>0.95x<br>
+      <td>0.96x<br>
       </td>
     </tr>
   </tbody>
@@ -732,8 +752,8 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
 <h4>Small struct test</h4>
 
 <table style="width: 100%" border="1">
-  <caption>Adding 5000000 small structs, each with a random unsigned int as one
-  of the members</caption>
+  <caption>Inserting 5000000 small structs, each with a random unsigned int as
+  one of the members</caption>
   <colgroup><col>
     <col>
     <col>
@@ -752,39 +772,39 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>330</td>
-      <td>301</td>
-      <td>454</td>
-      <td>505<br>
+      <td>337</td>
+      <td>311</td>
+      <td>434</td>
+      <td>496<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>141</td>
-      <td>120</td>
-      <td>209</td>
-      <td>168<br>
+      <td>143</td>
+      <td>122</td>
+      <td>189</td>
+      <td>165<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>125</td>
-      <td>110</td>
-      <td>157</td>
-      <td>136<br>
+      <td>129</td>
+      <td>115</td>
+      <td>133</td>
+      <td>121<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
+      <td>2.4x</td>
+      <td>2.6x</td>
       <td>2.3x</td>
-      <td>2.5x</td>
-      <td>2.2x</td>
       <td>3.0x<br>
       </td>
-      <td>2.5x<br>
+      <td>2.6x<br>
       </td>
     </tr>
   </tbody>
@@ -812,38 +832,38 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>37857</td>
-      <td>44893</td>
-      <td>36813</td>
-      <td>45229<br>
+      <td>37689</td>
+      <td>45834</td>
+      <td>38289</td>
+      <td>45743<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
       <td>78</td>
-      <td>71</td>
-      <td>93</td>
-      <td>87<br>
+      <td>65</td>
+      <td>102</td>
+      <td>82<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>66</td>
-      <td>61</td>
-      <td>91</td>
-      <td>67<br>
+      <td>67</td>
+      <td>55</td>
+      <td>97</td>
+      <td>68<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>485.4x</td>
-      <td>632.3x</td>
-      <td>395.8x</td>
-      <td>519.9x</td>
-      <td>508.4x<br>
+      <td>483x</td>
+      <td>705x</td>
+      <td>375x</td>
+      <td>557x</td>
+      <td>530x<br>
       </td>
     </tr>
   </tbody>
@@ -871,39 +891,39 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>3002</td>
-      <td>3528</td>
-      <td>2928</td>
-      <td>3793<br>
+      <td>3032</td>
+      <td>3517</td>
+      <td>2938</td>
+      <td>3837<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>2853</td>
-      <td>3698</td>
-      <td>3063</td>
-      <td>4014<br>
+      <td>2906</td>
+      <td>3614</td>
+      <td>3059</td>
+      <td>3939<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>2702</td>
-      <td>3470</td>
-      <td>2857</td>
-      <td>3521<br>
+      <td>2751</td>
+      <td>3485</td>
+      <td>2914</td>
+      <td>3495<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>1.05x</td>
-      <td>0.95x</td>
+      <td>1.04x</td>
+      <td>0.97x</td>
       <td>0.96x</td>
-      <td>0.95x<br>
+      <td>0.97x<br>
       </td>
-      <td>0.98x<br>
+      <td>0.99x<br>
       </td>
     </tr>
   </tbody>
@@ -916,8 +936,8 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
 <h4>Large struct test</h4>
 
 <table style="width: 100%" border="1">
-  <caption>Adding 10000 large structs, each with a random unsigned int as one
-  of the members</caption>
+  <caption>Inserting 10000 large structs, each with a random unsigned int as
+  one of the members</caption>
   <colgroup><col>
     <col>
     <col>
@@ -936,28 +956,28 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>313</td>
-      <td>261</td>
-      <td>437</td>
-      <td>460<br>
+      <td>310</td>
+      <td>269</td>
+      <td>442</td>
+      <td>464<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>97</td>
-      <td>101</td>
-      <td>98</td>
-      <td>103<br>
+      <td>96</td>
+      <td>103</td>
+      <td>99</td>
+      <td>104<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>95</td>
-      <td>100</td>
       <td>94</td>
-      <td>99<br>
+      <td>102</td>
+      <td>95</td>
+      <td>101<br>
       </td>
       <td></td>
     </tr>
@@ -996,26 +1016,26 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>7249</td>
-      <td>6187</td>
-      <td>7177</td>
-      <td>7316<br>
+      <td>7203</td>
+      <td>6235</td>
+      <td>7244</td>
+      <td>7383<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
       <td>&lt; 1</td>
-      <td>&lt; 1</td>
       <td>1</td>
-      <td>1<br>
+      <td>1</td>
+      <td>0<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>1</td>
-      <td>1</td>
+      <td>&lt; 1</td>
+      <td>&lt; 1</td>
       <td>&lt; 1</td>
       <td>0<br>
       </td>
@@ -1023,12 +1043,12 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>&gt; 7249x</td>
-      <td>&gt; 6187x</td>
-      <td>7177x</td>
-      <td>7316x<br>
+      <td>&gt; 7203x</td>
+      <td>6235x</td>
+      <td>7244x</td>
+      <td>&gt; 7383x<br>
       </td>
-      <td>&gt; 6982x<br>
+      <td>&gt; 7016x<br>
       </td>
     </tr>
   </tbody>
@@ -1056,39 +1076,39 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>477</td>
-      <td>479</td>
-      <td>479</td>
-      <td>587<br>
+      <td>478</td>
+      <td>480</td>
+      <td>480</td>
+      <td>557<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>515</td>
-      <td>509</td>
-      <td>568</td>
-      <td>649<br>
+      <td>516</td>
+      <td>517</td>
+      <td>569</td>
+      <td>659<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
       <td>519</td>
-      <td>529</td>
-      <td>511</td>
-      <td>529<br>
+      <td>531</td>
+      <td>513</td>
+      <td>530<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
       <td>0.93x</td>
-      <td>0.94x</td>
+      <td>0.93x</td>
       <td>0.84x</td>
-      <td>0.90x<br>
+      <td>0.86x<br>
       </td>
-      <td>0.90x<br>
+      <td>0.89x<br>
       </td>
     </tr>
   </tbody>
@@ -1101,7 +1121,7 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
 <h4>Small primitive type test</h4>
 
 <table style="width: 100%" border="1">
-  <caption>Adding 5000000 random unsigned ints</caption>
+  <caption>Inserting 5000000 random unsigned ints</caption>
   <colgroup><col>
     <col>
     <col>
@@ -1120,18 +1140,18 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>93</td>
-      <td>80</td>
-      <td>125</td>
-      <td>103<br>
+      <td>88</td>
+      <td>76</td>
+      <td>138</td>
+      <td>102<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>76</td>
-      <td>69</td>
-      <td>136</td>
+      <td>75</td>
+      <td>68</td>
+      <td>141</td>
       <td>99<br>
       </td>
       <td></td>
@@ -1139,17 +1159,17 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     <tr>
       <td>array</td>
       <td>71</td>
-      <td>65</td>
-      <td>94</td>
-      <td>76<br>
+      <td>59</td>
+      <td>103</td>
+      <td>72<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
       <td>1.2x</td>
-      <td>1.2x</td>
-      <td>0.9x</td>
+      <td>1.1x</td>
+      <td>1.0x</td>
       <td>1.0x<br>
       </td>
       <td>1.1x<br>
@@ -1180,39 +1200,39 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>3743</td>
-      <td>3705</td>
+      <td>3771</td>
       <td>3773</td>
-      <td>3760<br>
+      <td>3814</td>
+      <td>3810<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>78</td>
-      <td>62</td>
-      <td>98</td>
-      <td>80<br>
+      <td>74</td>
+      <td>63</td>
+      <td>107</td>
+      <td>78<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
       <td>67</td>
-      <td>60</td>
-      <td>91</td>
-      <td>68<br>
+      <td>56</td>
+      <td>98</td>
+      <td>67<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>48.0x</td>
-      <td>59.8x</td>
-      <td>38.5x</td>
-      <td>47.0x<br>
+      <td>51.0x</td>
+      <td>59.9x</td>
+      <td>35.7x</td>
+      <td>48.9x<br>
       </td>
-      <td>48.3x<br>
+      <td>48.9x<br>
       </td>
     </tr>
   </tbody>
@@ -1239,39 +1259,39 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>1226</td>
-      <td>459</td>
-      <td>459</td>
-      <td>461<br>
+      <td>1229</td>
+      <td>467</td>
+      <td>458</td>
+      <td>465<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>1241</td>
-      <td>844</td>
-      <td>1232</td>
-      <td>972<br>
+      <td>1246</td>
+      <td>978</td>
+      <td>720</td>
+      <td>721<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>1271</td>
-      <td>674</td>
-      <td>677</td>
-      <td>679<br>
+      <td>1276</td>
+      <td>686</td>
+      <td>728</td>
+      <td>682<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
       <td>0.99x</td>
-      <td>0.54x</td>
-      <td>0.37x</td>
-      <td>0.47x<br>
+      <td>0.48x</td>
+      <td>0.64x</td>
+      <td>0.65x<br>
       </td>
-      <td>0.59x<br>
+      <td>0.69x<br>
       </td>
     </tr>
   </tbody>
@@ -1346,9 +1366,8 @@ such as the meaning of using a number in the constructor.</p>
 
 <h3>Iterators/Reverse_iterators</h3>
 
-<p>Similar to all std:: iterators. Functionality for
-plf::colony&lt;&gt;::iterator and plf::colony&gt;&lt;&gt;::reverse_iterator
-below:</p>
+<p>Similar to all std:: iterators. Functionality for iterator,
+reverse_iterator, const_iterator and const_reverse_iterator below:</p>
 <code>*<br>
 -&gt;<br>
 ++<br>
@@ -1372,25 +1391,27 @@ end/beginning).</p>
 <p>reverse_iterator also has the base() command (same as STL) to return the
 internal iterator.</p>
 
-<p>Colony contains begin(), end(), rbegin() and rend() iterator return
-functions which follow standard std:: library rules. Example of usage:</p>
+<p>Colony contains begin(), end(), rbegin(), rend(), cbegin(), cend(),
+crbegin() and crend() iterator/const_iterator return functions which follow
+standard std:: library rules. Example of usage:</p>
 <code style="color: brown">for (plf::colony&lt;int&gt;::iterator the_iterator =
 data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
 {<br>
    total += *the_iterator;<br>
-}</code>
+}</code> 
 
 <h3>Basic functions</h3>
 <ul>
-  <li><code>iterator add(const the_type &amp;element)</code> 
-    <p>Adds the element supplied to the colony, using the object's
+  <li><code>iterator insert(const the_type &amp;element)</code> 
+    <p>Inserts the element supplied to the colony, using the object's
     copy-constructor. Will place the element in a previously erased element
     slot if one exists, otherwise will push to back of colony. Returns iterator
     to location of pushed element. Example:</p>
     <code style="color: brown">plf::colony&lt;unsigned int&gt;
     data_colony(50);<br>
-    data_colony.add(23);</code> </li>
-  <li><code>iterator add(the_type &amp;&amp;element) <b>C++11 only</b></code> 
+    data_colony.insert(23);</code> </li>
+  <li><code>iterator insert(the_type &amp;&amp;element) <b>C++11
+    only</b></code> 
     <p>Moves the element supplied to the colony, using the object's
     move-constructor. Will place the element in a previously erased element
     slot if one exists, otherwise will push to back of colony. Returns iterator
@@ -1406,39 +1427,21 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
     X.string1 = "Some text";<br>
     <br>
     plf::colony&lt;just_struct&gt; data_colony(50);<br>
-    data_colony.add(std::move(X));</code> </p>
+    data_colony.insert(std::move(X));</code> </p>
   </li>
-  <li><code>void add(iterator begin_iterator, iterator end_iterator)</code> 
-    <p>Adds the contents of a colony of same element type (eg. int, float, a
-    particular class, etcetera) to the given colony. Stops adding once it
+  <li><code>void insert(iterator begin_iterator, iterator end_iterator)</code> 
+    <p>Inserts the contents of a colony of same element type (eg. int, float, a
+    particular class, etcetera) to the given colony. Stops inserting once it
     reaches the end iterator. Example:</p>
-    <code style="color: brown">// Add all contents of colony2 to colony1:<br>
-    colony1.add(colony2.begin(), colony2.end());</code> </li>
-  <li><code>iterator add()</code> 
-    <p>Semantics are the same as "add(the_type())". This is simple
-    initialisation without writing any data to the element (at least, any data
-    that isn't written by the type's constructor). If the datatype is a class
-    this requires a default, parameterless, constructor (and typically a
-    separate initialisation function).<br>
-    If the datatype is a constructorless struct or primitive type eg. int, it
-    simply leaves the new object in an uninitialised state. In either case it
-    returns the constructed object/data location so you can access it and write
-    to it directly. This could be useful when you have a large class object and
-    you want to write directly to it within the colony rather than wasting CPU
-    cycles constructing it and then copying it to the colony. Also useful where
-    C++11 semantics (ie. emplace) are unavailable. A very simple (and unlikely)
-    example:</p>
-    <code style="color: brown">plf::colony&lt;unsigned int&gt;
-    data_colony(50);<br>
-    plf::colony&lt;unsigned int&gt;::iterator place;<br>
-    place = data_colony.add();<br>
-    *place = 23;</code> </li>
+    <code style="color: brown">// Insert all contents of colony2 into
+    colony1:<br>
+    colony1.insert(colony2.begin(), colony2.end());</code> </li>
   <li><code>iterator emplace(parameters...) <b>C++11 only</b></code> 
-    <p>Same as Add but constructs object in-place rather than copying another
-    object into the colony. Similar to std:: library emplace with the exception
-    that no insertion location is specified. Location depends on same behaviour
-    as Add. "parameters..." are whatever parameters are required by the
-    object's constructor. Example:</p>
+    <p>Same as insert but constructs object in-place rather than copying
+    another object into the colony. Similar to std:: library emplace with the
+    exception that no insertion location is specified. Location depends on same
+    behaviour as insert. "parameters..." are whatever parameters are required
+    by the object's constructor. Example:</p>
     <p><code style="color: brown">class simple_class<br>
     {<br>
     private:<br>
@@ -1460,7 +1463,7 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
     <code style="color: brown">plf::colony&lt;unsigned int&gt;
     data_colony(50);<br>
     plf::colony&lt;unsigned int&gt;::iterator an_iterator;<br>
-    an_iterator = data_colony.add(23);<br>
+    an_iterator = data_colony.insert(23);<br>
     an_iterator = data_colony.erase(an_iterator);</code> </li>
   <li><code>void erase(const iterator &amp;begin_iterator, const iterator
     &amp;end_iterator)</code> 
@@ -1529,12 +1532,12 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
     order of container elements is not important, and:</p>
     <ol type="a">
       <li>Pointers and iterators which point to container elements must stay
-        valid regardless of container additions and deletions,<br>
+        valid regardless of container insertions and erasures,<br>
         <br>
         <b>and/or</b><br>
       </li>
-      <li>Additions to or deletions from the container will be occuring in
-        realtime ie. in performance-critical code.</li>
+      <li>Insertions and erasures to the container will be occuring in realtime
+        ie. in performance-critical code.</li>
     </ol>
     <p>Under these circumstances a colony out-performs all std:: containers.<br>
     In addition: because it never invalidates pointer or iterator references to
@@ -1545,10 +1548,10 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
   </li>
   <li><h4>What are the performance characteristics?</h4>
     <p>As above, also, see the <a href="#benchmarks">benchmarks</a>. On
-    larger-than-scalar types, adding to a colony is typically twice as fast as
-    a vector, erasing from is many multiples-of-ten faster, and iteration about
-    the same (or slightly slower, but not by a meaningful ratio). For scalar
-    types (ie. int, float etc) it does not perform as well.</p>
+    larger-than-scalar types, inserting to a colony is typically twice as fast
+    as a vector, erasing from is many multiples-of-ten faster, and iteration
+    about the same (or slightly slower, but not by a meaningful ratio). For
+    scalar types (ie. int, float etc) it does not perform as well.</p>
   </li>
   <li><h4>What are some examples of situations where a colony improves
     performance?</h4>
@@ -1561,14 +1564,18 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
   </li>
   <li><h4>Are there situations where one would prefer a vector over a
     colony?</h4>
-    <p>Yes, in the circumstance where all additions to and deletions from a
+    <p>Yes, in the circumstance where all insertions to and erasures from a
     container occur outside of performance-critical areas of code, while the
-    main code merely iterates over the container and never adds or deletes from
-    the container, you may find a vector more performant, provided nothing has
-    to refer to individual container elements in other sections of the program
-    (which would necessitate a vector of pointers to dynamically-allocated
-    objects in order to ensure reference validity - which has poor cache
-    performance).</p>
+    main code merely iterates over the container and never inserts or erases
+    to/from the container, you may find a vector better-performing, provided
+    nothing has to refer to individual container elements in other sections of
+    the program (which would necessitate a vector of pointers to
+    dynamically-allocated objects in order to ensure reference validity - which
+    has poor cache performance).</p>
+    <p>In the case of small scalar types and low amounts of realtime
+    insert/erase, you may find a vector faster, although insert/erase are
+    always at least factors of ten longer in duration than iteration times,
+    regardless of container. So benchmarking is required.</p>
     <p>Also, as noted, a vector is easier to use when dealing with ordered
     data. You may sort the data in a colony by iterating over it with a
     swapping/sorting function, but you cannot control insertion placement.</p>
@@ -1591,15 +1598,6 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
     doubling-of-memory-space-on-expansion rule that vectors do, colonies are
     probably more similar to a vector despite using a very different internal
     schema.</p>
-  </li>
-  <li><h4>Why is the function called "add" instead of "insert" or "push"?</h4>
-    <p>Because the semantics are different to insert or push.<br>
-    Insert always takes an insertion position, add doesn't take a position.<br>
-    Push is always accompanied by both "back" and "pop" functions, neither of
-    which are used in colonies, and it does not return an iterator, which "add"
-    must do.<br>
-    "Push" is probably the closest in terms of semantics, but I chose a
-    different name to be clear.</p>
   </li>
   <li><h4>Will ordered insert be added to the functions?</h4>
     <p>It is possible, and would be much faster than vector's insert - as
@@ -1632,9 +1630,9 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
   <li><h4>Any "gotcha"'s to watch out for?</h4>
     <p>Only a few:</p>
     <ol type="a">
-      <li>"add" placement can be at the back, front, or frankly anywhere in the
-        container, depending on what's been deleted previously and where it
-      was.</li>
+      <li>"insert" placement can be at the back, front, or frankly anywhere in
+        the container, depending on what's been deleted previously and where it
+        was.</li>
       <li><code>plf::colony&lt;int&gt; a_colony(500);</code> does not mean the
         same thing as <code>std::vector&lt;int&gt; a_vector(500);</code>. A
         vector inserts 500 elements using the type's default constructor when
@@ -1662,15 +1660,15 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
   </li>
   <li><h4>Any special-case uses?</h4>
     <p>In the special case where many, many elements are being continually
-    erased/added in realtime, you might want to consider limiting the size of
-    your internal memory blocks in the constructor. The form of this is as
+    erased/inserted in realtime, you might want to consider limiting the size
+    of your internal memory blocks in the constructor. The form of this is as
     follows:<br>
     <code>plf::vector&lt;object&gt; a_vector(500, 5000);</code><br>
     where the first number is the minimum size of the internal memory blocks
     and the second is the maximum size.<br>
     The reason for this is that it is, slightly, slower to pop an element
     location off the internal memory position recycling stack, than it is to
-    add a new element to the end of the colony (the default behaviour when
+    insert a new element to the end of the colony (the default behaviour when
     there are no previously-erased elements). If there are any erased elements
     in the colony, the colony will recycle those memory locations, unless the
     entire block is empty, at which point it is freed to memory. If a block

--- a/Docs/plflib documentation - local cached copy - may become out of date/stack.htm
+++ b/Docs/plflib documentation - local cached copy - may become out of date/stack.htm
@@ -50,7 +50,7 @@ a #include command. The package includes both plf::colony and plf::stack.</p>
 
 <h2>Benchmarks</h2>
 
-<p style="font-size: 75%"><i>Last updated 13-7-2015 v1.70</i></p>
+<p style="font-size: 75%"><i>Last updated 5-10-2015 v2.20</i></p>
 
 <p>This benchmark compares performance between std::vector and plf::stack. I'm
 using std::vector instead of std::stack, as while std::stack usually uses
@@ -97,26 +97,26 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>331</td>
-      <td>302</td>
-      <td>456</td>
-      <td>508</td>
+      <td>332</td>
+      <td>312</td>
+      <td>433</td>
+      <td>497</td>
       <td></td>
     </tr>
     <tr>
       <td>plf::stack</td>
-      <td>134</td>
-      <td>114</td>
-      <td>185</td>
       <td>149</td>
+      <td>117</td>
+      <td>167</td>
+      <td>140</td>
       <td></td>
     </tr>
     <tr>
       <td>stack vs vector performance</td>
-      <td>2.5x</td>
+      <td>2.3x</td>
       <td>2.7x</td>
-      <td>2.5x</td>
-      <td>3.4x</td>
+      <td>2.6x</td>
+      <td>3.6x</td>
       <td>2.8x</td>
     </tr>
   </tbody>
@@ -143,26 +143,26 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     <tr>
       <td>std::vector</td>
       <td>45</td>
-      <td>38</td>
-      <td>52</td>
-      <td>42</td>
+      <td>39</td>
+      <td>30</td>
+      <td>43</td>
       <td></td>
     </tr>
     <tr>
       <td>plf::stack</td>
+      <td>48</td>
+      <td>36</td>
+      <td>30</td>
       <td>46</td>
-      <td>38</td>
-      <td>53</td>
-      <td>44</td>
       <td></td>
     </tr>
     <tr>
       <td>stack vs vector performance</td>
-      <td>0.98x</td>
+      <td>0.94x</td>
+      <td>1.08x</td>
       <td>1.0x</td>
-      <td>0.98x</td>
-      <td>0.96x</td>
-      <td>0.98x</td>
+      <td>0.94x</td>
+      <td>0.99x</td>
     </tr>
   </tbody>
 </table>
@@ -194,16 +194,16 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>313</td>
-      <td>262</td>
-      <td>438</td>
-      <td>460</td>
+      <td>311</td>
+      <td>269</td>
+      <td>442</td>
+      <td>465</td>
       <td></td>
     </tr>
     <tr>
       <td>plf::stack</td>
-      <td>97</td>
-      <td>101</td>
+      <td>96</td>
+      <td>103</td>
       <td>99</td>
       <td>104</td>
       <td></td>
@@ -212,9 +212,9 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
       <td>stack vs vector performance</td>
       <td>3.2x</td>
       <td>2.6x</td>
-      <td>4.4x</td>
-      <td>4.4x</td>
-      <td>3.7x</td>
+      <td>4.5x</td>
+      <td>4.5x</td>
+      <td>3.8x</td>
     </tr>
   </tbody>
 </table>
@@ -288,27 +288,27 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>188</td>
-      <td>163</td>
-      <td>263</td>
-      <td>233</td>
+      <td>179</td>
+      <td>177</td>
+      <td>288</td>
+      <td>229</td>
       <td></td>
     </tr>
     <tr>
       <td>plf::stack</td>
-      <td>136</td>
-      <td>135</td>
-      <td>228</td>
-      <td>160</td>
+      <td>138</td>
+      <td>117</td>
+      <td>239</td>
+      <td>161</td>
       <td></td>
     </tr>
     <tr>
       <td>stack vs vector performance</td>
-      <td>1.4x</td>
-      <td>1.2x</td>
-      <td>1.2x</td>
-      <td>1.5x</td>
       <td>1.3x</td>
+      <td>1.5x</td>
+      <td>1.2x</td>
+      <td>1.4x</td>
+      <td>1.4x</td>
     </tr>
   </tbody>
 </table>
@@ -335,25 +335,25 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
       <td>std::vector</td>
       <td>24</td>
       <td>9</td>
-      <td>10</td>
+      <td>17</td>
       <td>29</td>
       <td></td>
     </tr>
     <tr>
       <td>plf::stack</td>
-      <td>25</td>
+      <td>24</td>
+      <td>13</td>
       <td>17</td>
-      <td>17</td>
-      <td>34</td>
+      <td>37</td>
       <td></td>
     </tr>
     <tr>
       <td>stack vs vector performance</td>
-      <td>0.96x</td>
-      <td>0.53x</td>
-      <td>0.59x</td>
-      <td>0.85x</td>
-      <td>0.73x</td>
+      <td>1.00x</td>
+      <td>0.69x</td>
+      <td>1.00x</td>
+      <td>0.78x</td>
+      <td>0.87x</td>
     </tr>
   </tbody>
 </table>

--- a/SG14_test/plf_benchmark.cpp
+++ b/SG14_test/plf_benchmark.cpp
@@ -1,5 +1,7 @@
+// Copyright (c) 2015, Matthew Bentley (mattreecebentley@gmail.com) www.plflib.org
+
 // About: there are 8 tests here;
-// one with a vector of dynamically-allocated objects vs colony, array with boolean field, list, map and deque(small structs)
+// one with a vector of dynamically-allocated objects vs colony, array with boolean field, list, map and deque of dynamically-allocated objects (small structs)
 // one with vector with boolean field, deque with boolean field and array with boolean field vs colony (small structs)
 // three with vector vs colony vs array vs deque with boolean field (unsigned ints, small structs and large structs)
 // three with vector vs plf::stack (unsigned ints, small structs and large structs)
@@ -125,7 +127,7 @@ int main(int argc, char **argv)
 		cin.get();
 
 		cout << "small struct tests begin:" << endl << endl;
-		cout << "milliseconds to add 2000000 generic structs:" << endl;
+		cout << "milliseconds to insert 2000000 generic structs:" << endl;
 		one_sec_delay(); // to remove potential overhead from cout.
 
 		unsigned long current_time, difference1, difference2, difference3, difference4, difference5, difference6;
@@ -149,7 +151,7 @@ int main(int argc, char **argv)
 		for (unsigned int num = 0; num != 2000000; ++num)
 		{
 			the_struct.number = rand() % 1000000;
-			data_colony.add(the_struct);
+			data_colony.insert(the_struct);
 		}
 
 		difference2 = get_time_in_ms() - current_time;
@@ -453,7 +455,7 @@ int main(int argc, char **argv)
 		cin.get();
 
 		cout << "small struct tests begin:" << endl << endl;
-		cout << "milliseconds to add 5000000 generic structs:" << endl;
+		cout << "milliseconds to insert 5000000 generic structs:" << endl;
 		
 		one_sec_delay(); // to remove potential overhead from cout.
 
@@ -476,7 +478,7 @@ int main(int argc, char **argv)
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
 			the_struct.number = rand() % 5000000;
-			data_colony.add(the_struct);
+			data_colony.insert(the_struct);
 		}
 
 		difference2 = get_time_in_ms() - current_time;
@@ -671,7 +673,7 @@ int main(int argc, char **argv)
 		cin.get();
 	
 		cout << "Unsigned int tests begin." << endl << endl;
-		cout << "Milliseconds to add 50000000 unsigned ints:" << endl;
+		cout << "Milliseconds to insert 50000000 unsigned ints:" << endl;
 		
 		one_sec_delay(); // To remove potential overhead from cout.
 	
@@ -689,7 +691,7 @@ int main(int argc, char **argv)
 	
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
-			data_colony.add(rand() % 5000000);
+			data_colony.insert(rand() % 5000000);
 		}
 	
 		difference2 = get_time_in_ms() - current_time;
@@ -875,7 +877,7 @@ int main(int argc, char **argv)
 		cin.get();
 
 		cout << "Small struct tests begin:" << endl << endl;
-		cout << "Milliseconds to add 5000000 generic structs:" << endl;
+		cout << "Milliseconds to insert 5000000 generic structs:" << endl;
 		
 		one_sec_delay(); // To remove potential overhead from cout.
 
@@ -896,7 +898,7 @@ int main(int argc, char **argv)
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
 			the_struct.number = rand() % 5000000;
-			data_colony.add(the_struct);
+			data_colony.insert(the_struct);
 		}
 
 		difference2 = get_time_in_ms() - current_time;
@@ -1087,7 +1089,7 @@ int main(int argc, char **argv)
 		cin.get();
 
 		cout << "Large struct tests begin:" << endl << endl;
-		cout << "Milliseconds to add 10000 large structs:" << endl;
+		cout << "Milliseconds to insert 10000 large structs:" << endl;
   
 		one_sec_delay(); // To remove potential overhead from cout.
 
@@ -1108,7 +1110,7 @@ int main(int argc, char **argv)
 		for (unsigned int num = 0; num != 10000; ++num)
 		{
 			the_struct.number = rand() % 10000;
-			data_colony.add(the_struct);
+			data_colony.insert(the_struct);
 		}
 
 		difference2 = get_time_in_ms() - current_time;
@@ -1523,8 +1525,6 @@ int main(int argc, char **argv)
  		cin.get();
 		cout << endl << endl << endl << endl << endl << endl << endl << endl;
 	}
-
-
 
 
 	return 0;

--- a/SG14_test/plf_test_suite.cpp
+++ b/SG14_test/plf_test_suite.cpp
@@ -1,413 +1,481 @@
 #include <iostream>
+#include <algorithm>
+#include <cstdio> // log redirection
 #include <cstdlib> // rand
-#include <ctime> // clock()
+#include <ctime> // timer
 #include "plf_colony.h"
 
 
 #define TITLE1(title_text) \
 	std::cout << std::endl << std::endl << std::endl << "*** " << title_text << " ***" << std::endl; \
-	std::cout << "===========================================" << std::endl << std::endl << std::endl;
-
+	std::cout << "===========================================" << std::endl << std::endl << std::endl; 
 
 #define TITLE2(title_text) \
-	std::cout << std::endl << std::endl << "--- " << title_text << " ---" << std::endl << std::endl;
+	std::cout << std::endl << std::endl << "--- " << title_text << " ---" << std::endl << std::endl; 
 
+	
+#define PASS std::cout << "Pass" << std::endl;
+
+#define FAIL std::cout << "Fail" << std::endl;
 
 #define FAILPASS(test_type, condition) \
 	std::cout << test_type << ": "; \
 	\
 	if (condition) \
 	{ \
-		std::cout << "Pass" << std::endl; \
+		PASS \
 	} \
 	else \
 	{ \
-		std::cout << "Fail" << std::endl; \
+		FAIL \
 		std::cin.get(); \
+		abort(); \
 	}
+
 
 
 namespace sg14_test
 {
 
-	void plf_test_suite()
+void plf_test_suite()
+{
+	srand(clock()); // Note: using random numbers to avoid CPU predictive
+
+	using namespace std;
+	using namespace plf;
+
+
+	unsigned int looper = 0;
+	
+	while (++looper != 50)
 	{
-		srand(clock()); // Note: using random numbers to avoid CPU predictive
 
-		using namespace std;
-		using namespace plf;
+	{
+		TITLE1("Colony")
+		TITLE2("Test Basics")
+		
+		colony<int *> p_colony;
+		
+		FAILPASS("Colony empty", p_colony.empty())
+		
+		int ten = 10;
+		p_colony.insert(&ten);
+		
+		FAILPASS("Colony not-empty", !p_colony.empty())
+	
+		TITLE2("Iterator tests")
+		
+		FAILPASS("Begin() working", **p_colony.begin() == 10)
+		FAILPASS("End() working", p_colony.begin() != p_colony.end())
+		
 
+		p_colony.clear();
 
-		unsigned int looper = 0;
+		FAILPASS("Begin = End after clear", p_colony.begin() == p_colony.end())
 
-		TITLE1("plf::colony and plf::stack tests - these tests will repeat 50 times in order to cover a wide variety of randomised scenarios. Please press ENTER.")
-			cin.get();
-
-		while (++looper != 50)
+		int twenty = 20;
+		
+		for (unsigned int temp = 0; temp != 200; ++temp)
 		{
-
-			{
-				TITLE1("Colony")
-					TITLE2("Test Basics")
-
-					colony<int *> p_colony;
-
-				FAILPASS("Colony empty", p_colony.empty())
-
-					int ten = 10;
-				p_colony.add(&ten);
-
-				FAILPASS("Colony not-empty", !p_colony.empty())
-
-					TITLE2("Iterator tests")
-
-					FAILPASS("Begin() working", **p_colony.begin() == 10)
-					FAILPASS("End() working", p_colony.begin() != p_colony.end())
-
-
-					p_colony.clear();
-
-				FAILPASS("Begin = End after clear", p_colony.begin() == p_colony.end())
-
-					int twenty = 20;
-
-				for (unsigned int temp = 0; temp != 200; ++temp)
-				{
-					p_colony.add(&ten);
-					p_colony.add(&twenty);
-				}
-
-				unsigned int total = 0, numtotal = 0;
-
-				for (colony<int *>::iterator the_iterator = p_colony.begin(); the_iterator != p_colony.end(); ++the_iterator)
-				{
-					++total;
-					numtotal += **the_iterator;
-				}
-
-				FAILPASS("Iteration count test", total == 400)
-					FAILPASS("Iterator access test", numtotal == 6000)
-
-					numtotal = 0;
-				total = 0;
-
-				for (colony<int *>::reverse_iterator the_iterator = p_colony.rbegin(); the_iterator != p_colony.rend(); ++the_iterator)
-				{
-					++total;
-					numtotal += **the_iterator;
-				}
-
-
-				FAILPASS("Reverse iteration count test", total == 400)
-					FAILPASS("Reverse iterator access test", numtotal == 6000)
-
-					numtotal = 0;
-				total = 0;
-
-				for (colony<int *>::iterator the_iterator = p_colony.begin(); the_iterator < p_colony.end(); the_iterator += 2)
-				{
-					++total;
-					numtotal += **the_iterator;
-				}
-
-				FAILPASS("Multiple iteration test", total == 200)
-					FAILPASS("Multiple iteration access test", numtotal == 2000)
-
-					total = 0;
-
-				for (colony<int *>::iterator the_iterator = p_colony.begin() + 1; the_iterator < p_colony.end(); ++the_iterator)
-				{
-					++total;
-					the_iterator = p_colony.erase(the_iterator);
-				}
-
-				FAILPASS("Partial erase iteration test", total == 200)
-					FAILPASS("Post-erase size test", p_colony.size() == 200)
-
-					total = 0;
-
-				for (colony<int *>::reverse_iterator the_iterator = p_colony.rbegin(); the_iterator != p_colony.rend();)
-				{
-					the_iterator = p_colony.erase(the_iterator.base() - 1);
-					++the_iterator;
-					++total;
-				}
-
-				FAILPASS("Full erase reverse iteration test", total == 200)
-					FAILPASS("Post-erase size test", p_colony.size() == 0)
-
-					for (unsigned int temp = 0; temp != 200; ++temp)
-					{
-						p_colony.add(&ten);
-						p_colony.add(&twenty);
-					}
-
-				total = 0;
-
-				for (colony<int *>::iterator the_iterator = p_colony.end() - 1; the_iterator != p_colony.begin(); --the_iterator)
-				{
-					++total;
-				}
-
-				FAILPASS("Negative iteration test", total == 399)
-
-
-					total = 0;
-
-				for (colony<int *>::iterator the_iterator = p_colony.end() - 1; the_iterator != p_colony.begin(); the_iterator -= 2)
-				{
-					++total;
-				}
-
-				FAILPASS("Negative multiple iteration test", total == 200)
-			}
-
-
-			{
-				TITLE1("Add and Erase tests")
-
-					colony<int> i_colony;
-
-				for (unsigned int temp = 0; temp != 500000; ++temp)
-				{
-					i_colony.add(temp);
-				}
-
-				FAILPASS("Size after add test", i_colony.size() == 500000)
-
-					for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end(); ++the_iterator)
-					{
-						the_iterator = i_colony.erase(the_iterator);
-					}
-
-				FAILPASS("Erase alternating test", i_colony.size() == 250000)
-
-					do
-					{
-						for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
-						{
-							if (rand() % 5 == 0)
-							{
-								the_iterator = i_colony.erase(the_iterator);
-							}
-							else
-							{
-								++the_iterator;
-							}
-						}
-
-					} while (!i_colony.empty());
-
-					FAILPASS("Erase randomly till-empty test", i_colony.size() == 0)
-
-
-						i_colony.reinitialize(10000);
-
-					for (unsigned int temp = 0; temp != 30000; ++temp)
-					{
-						i_colony.add(1);
-					}
-
-					FAILPASS("Size after reinitialize + add test", i_colony.size() == 30000)
-
-
-						unsigned int sum = 0;
-
-					for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
-					{
-						if (++sum == 3)
-						{
-							sum = 0;
-							the_iterator = i_colony.erase(the_iterator);
-						}
-						else
-						{
-							i_colony.add(1);
-							++the_iterator;
-						}
-					}
-
-					FAILPASS("Alternating add/erase test", i_colony.size() == 45001)
-
-
-						do
-						{
-							for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
-							{
-								if (rand() % 3 == 0)
-								{
-									++the_iterator;
-									i_colony.add(1);
-								}
-								else
-								{
-									the_iterator = i_colony.erase(the_iterator);
-								}
-							}
-						} while (!i_colony.empty());
-
-						FAILPASS("Random add/erase till empty test", i_colony.size() == 0)
-
-
-							for (unsigned int temp = 0; temp != 500000; ++temp)
-							{
-								i_colony.add(10);
-							}
-
-						FAILPASS("Add post-erase test", i_colony.size() == 500000)
-
-							for (colony<int>::iterator the_iterator = i_colony.begin() + 250000; the_iterator != i_colony.end();)
-							{
-								the_iterator = i_colony.erase(the_iterator);
-							}
-
-						FAILPASS("Large multi-increment iterator test", i_colony.size() == 250000)
-
-
-							for (unsigned int temp = 0; temp != 250000; ++temp)
-							{
-								i_colony.add(10);
-							}
-
-						colony<int>::iterator end_iterator = i_colony.end() - 250000;
-
-						for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != end_iterator;)
-						{
-							the_iterator = i_colony.erase(the_iterator);
-						}
-
-						FAILPASS("Large multi-decrement iterator test", i_colony.size() == 250000)
-
-
-							for (unsigned int temp = 0; temp != 250000; ++temp)
-							{
-								i_colony.add(10);
-							}
-
-
-						unsigned int total = 0;
-
-						for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end(); ++the_iterator)
-						{
-							total += *the_iterator;
-						}
-
-						FAILPASS("Re-add post-heavy-erasure test", total == 5000000)
-
-
-							end_iterator = i_colony.end() - 1;
-						end_iterator -= 50000;
-
-						for (colony<int>::iterator the_iterator = i_colony.begin() + 300000; the_iterator != end_iterator;)
-						{
-							the_iterator = i_colony.erase(the_iterator);
-						}
-
-						FAILPASS("Non-end decrement + erase test", i_colony.size() == 350001)
-
-
-							for (unsigned int temp = 0; temp != 100000; ++temp)
-							{
-								i_colony.add(10);
-							}
-
-						colony<int>::iterator begin_iterator = i_colony.begin() + 2;
-						begin_iterator += 299998;
-
-
-						for (colony<int>::iterator the_iterator = begin_iterator; the_iterator != i_colony.end();)
-						{
-							the_iterator = i_colony.erase(the_iterator);
-						}
-
-						FAILPASS("Non-beginning increment + erase test", i_colony.size() == 300000)
-
-							for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
-							{
-								the_iterator = i_colony.erase(the_iterator);
-							}
-
-						FAILPASS("Final erase test", i_colony.empty())
-
-
-							i_colony.reinitialize(3);
-
-						unsigned int count = 0;
-
-						for (unsigned int loop1 = 0; loop1 != 50000; ++loop1)
-						{
-							for (unsigned int loop = 0; loop != 10; ++loop)
-							{
-								if (rand() % 5 == 0)
-								{
-									i_colony.add(1);
-									++count;
-								}
-							}
-
-							for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
-							{
-								if (rand() % 5 == 0)
-								{
-									the_iterator = i_colony.erase(the_iterator);
-									--count;
-								}
-								else
-								{
-									++the_iterator;
-								}
-							}
-						}
-
-						FAILPASS("Multiple sequential small add/erase commands test", count == i_colony.size())
-
-			}
-
-
-
-			{
-				TITLE1("Stack Tests")
-
-					stack<unsigned int> i_stack(50);
-
-				for (unsigned int temp = 0; temp != 250000; ++temp)
-				{
-					i_stack.push(10);
-				}
-
-				FAILPASS("Multipush test", i_stack.size() == 250000)
-
-
-					unsigned int total = 0;
-
-				for (unsigned int temp = 0; temp != 200000; ++temp)
-				{
-					total += i_stack.back();
-					i_stack.pop();
-				}
-
-				FAILPASS("Multipop test", i_stack.size() == 50000)
-					FAILPASS("Back() test", total == 2000000)
-
-					do
-					{
-						if (rand() % 5 == 0)
-						{
-							i_stack.push(10);
-						}
-						else
-						{
-							i_stack.pop();
-						}
-					} while (!i_stack.empty());
-
-					FAILPASS("Randomly pop/push till empty test", i_stack.size() == 0)
-			}
-
+			p_colony.insert(&ten);
+			p_colony.insert(&twenty);
+		}
+		
+		unsigned int total = 0, numtotal = 0;
+		
+		for(colony<int *>::iterator the_iterator = p_colony.begin(); the_iterator != p_colony.end(); ++the_iterator)
+		{
+			++total;
+			numtotal += **the_iterator;
+		}
+		
+		FAILPASS("Iteration count test", total == 400)
+		FAILPASS("Iterator access test", numtotal == 6000)
+
+		FAILPASS("Iterator + Iterator test", (p_colony.begin() + (p_colony.begin() + 20)) == 20);
+		FAILPASS("Iterator - Iterator test", ((p_colony.begin() + 200) - p_colony.begin() == 200));
+		
+		colony<int *> p_colony2 = p_colony;
+		colony<int *> p_colony3(p_colony);
+		
+		FAILPASS("Copy test", p_colony2.size() == 400)
+		FAILPASS("Copy construct test", p_colony3.size() == 400)
+		
+		FAILPASS("Equality operator test", p_colony == p_colony2)
+		FAILPASS("Equality operator test 2", p_colony2 == p_colony3)
+		
+		p_colony2.insert(&ten);
+		
+		FAILPASS("Inequality operator test", p_colony2 != p_colony3)
+
+		numtotal = 0;
+		total = 0;
+		
+		for (colony<int *>::reverse_iterator the_iterator = p_colony.rbegin(); the_iterator != p_colony.rend(); ++the_iterator)
+		{
+			++total;
+			numtotal += **the_iterator;
 		}
 
-		TITLE1("Test Suite PASS - Press ENTER to Exit")
-			cin.get();
+
+		FAILPASS("Reverse iteration count test", total == 400)
+		FAILPASS("Reverse iterator access test", numtotal == 6000)
+		
+		numtotal = 0;
+		total = 0;
+
+		for(colony<int *>::iterator the_iterator = p_colony.begin(); the_iterator < p_colony.end(); the_iterator += 2)
+		{
+			++total;
+			numtotal += **the_iterator;
+		}
+
+		FAILPASS("Multiple iteration test", total == 200)
+		FAILPASS("Multiple iteration access test", numtotal == 2000)
+
+		numtotal = 0;
+		total = 0;
+
+		for(colony<int *>::const_iterator the_iterator = p_colony.cbegin(); the_iterator != p_colony.cend(); ++the_iterator)
+		{
+			++total;
+			numtotal += **the_iterator;
+		}
+
+		FAILPASS("Const_iterator test", total == 400)
+		FAILPASS("Const_iterator access test", numtotal == 6000)
+
+
+		numtotal = 0;
+		total = 0;
+
+		for(colony<int *>::const_reverse_iterator the_iterator = p_colony.crend() - 1; the_iterator != p_colony.crbegin() - 1; --the_iterator)
+		{
+			++total;
+			numtotal += **the_iterator;
+		}
+
+		FAILPASS("Const_reverse_iterator -- test", total == 400)
+		FAILPASS("Const_reverse_iterator -- access test", numtotal == 6000)
+
+		total = 0;
+		
+		for(colony<int *>::iterator the_iterator = p_colony.begin() + 1; the_iterator < p_colony.end(); ++the_iterator)
+		{
+			++total;
+			the_iterator = p_colony.erase(the_iterator);
+		}
+
+		FAILPASS("Partial erase iteration test", total == 200)
+		FAILPASS("Post-erase size test", p_colony.size() == 200)
+
+		total = 0;
+
+		for(colony<int *>::reverse_iterator the_iterator = p_colony.rbegin(); the_iterator != p_colony.rend(); ++the_iterator)
+		{
+			colony<int *>::iterator it = the_iterator.base();
+			the_iterator = p_colony.erase(--it);
+			++total;
+		}
+
+		FAILPASS("Full erase reverse iteration test", total == 200)
+		FAILPASS("Post-erase size test", p_colony.size() == 0)
+
+		for (unsigned int temp = 0; temp != 200; ++temp)
+		{
+			p_colony.insert(&ten);
+			p_colony.insert(&twenty);
+		}
+		
+		total = 0;
+
+		for(colony<int *>::iterator the_iterator = p_colony.end() - 1; the_iterator != p_colony.begin(); --the_iterator)
+		{
+			++total;
+		}
+		
+		FAILPASS("Negative iteration test", total == 399)
+
+
+		total = 0;
+
+		for(colony<int *>::iterator the_iterator = p_colony.end() - 1; the_iterator != p_colony.begin(); the_iterator -= 2)
+		{
+			++total;
+		}
+
+		FAILPASS("Negative multiple iteration test", total == 200)
 	}
+	
+	
+	{
+		TITLE1("Insert and Erase tests")
+		
+		colony<int> i_colony;
+
+		for (unsigned int temp = 0; temp != 500000; ++temp)
+		{
+			i_colony.insert(temp);
+		}
+		
+		
+		FAILPASS("Size after insert test", i_colony.size() == 500000)
+
+
+		colony<int>::iterator found_item = std::find(i_colony.begin(), i_colony.end(), 5000);
+		
+		FAILPASS("std::find iterator test", *found_item == 5000)
+		
+		
+		colony<int>::reverse_iterator found_item2 = std::find(i_colony.rbegin(), i_colony.rend(), 5000);
+		
+		FAILPASS("std::find reverse_iterator test", *found_item2 == 5000)
+		
+		
+		for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end(); ++the_iterator)
+		{
+			the_iterator = i_colony.erase(the_iterator);
+		}
+
+		FAILPASS("Erase alternating test", i_colony.size() == 250000)
+
+		do
+		{
+			for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
+			{
+				if (rand() % 5 == 0)
+				{
+					the_iterator = i_colony.erase(the_iterator);
+				}
+				else
+				{
+					++the_iterator;
+				}
+			}
+			
+		} while (!i_colony.empty());
+		
+		FAILPASS("Erase randomly till-empty test", i_colony.size() == 0)
+
+
+		i_colony.reinitialize(10000);
+		
+		for (unsigned int temp = 0; temp != 30000; ++temp)
+		{
+			i_colony.insert(1);
+		}
+		
+		FAILPASS("Size after reinitialize + insert test", i_colony.size() == 30000)
+
+
+		unsigned int sum = 0;
+
+		for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
+		{
+			if (++sum == 3)
+			{
+				sum = 0;
+				the_iterator = i_colony.erase(the_iterator);
+			}
+			else
+			{
+				i_colony.insert(1);
+				++the_iterator;
+			}
+		}
+		
+		FAILPASS("Alternating insert/erase test", i_colony.size() == 45001)
+
+		
+		do
+		{
+			for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
+			{
+				if (rand() % 3 == 0)
+				{
+					++the_iterator;
+					i_colony.insert(1);
+				}
+				else
+				{
+					the_iterator = i_colony.erase(the_iterator);
+				}
+			}
+		} while (!i_colony.empty());
+		
+		FAILPASS("Random insert/erase till empty test", i_colony.size() == 0)
+
+		
+		for (unsigned int temp = 0; temp != 500000; ++temp)
+		{
+			i_colony.insert(10);
+		}
+		
+		FAILPASS("Insert post-erase test", i_colony.size() == 500000)
+
+		for (colony<int>::iterator the_iterator = i_colony.begin() + 250000; the_iterator != i_colony.end();)
+		{
+			the_iterator = i_colony.erase(the_iterator);
+		}
+		
+		FAILPASS("Large multi-increment iterator test", i_colony.size() == 250000)
+
+		
+		for (unsigned int temp = 0; temp != 250000; ++temp)
+		{
+			i_colony.insert(10);
+		}
+		
+		colony<int>::iterator end_iterator = i_colony.end() - 250000;
+		
+		for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != end_iterator;)
+		{
+			the_iterator = i_colony.erase(the_iterator);
+		}
+
+		FAILPASS("Large multi-decrement iterator test", i_colony.size() == 250000)
+
+		
+		for (unsigned int temp = 0; temp != 250000; ++temp)
+		{
+			i_colony.insert(10);
+		}
+		
+		
+		unsigned int total = 0;
+		
+		for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end(); ++the_iterator)
+		{
+			total += *the_iterator;
+		}
+
+		FAILPASS("Re-insert post-heavy-erasure test", total == 5000000)
+		
+
+		end_iterator = i_colony.end() - 1;
+		end_iterator -= 50000;
+
+		for (colony<int>::iterator the_iterator = i_colony.begin() + 300000; the_iterator != end_iterator;)
+		{
+			the_iterator = i_colony.erase(the_iterator);
+		}
+
+		FAILPASS("Non-end decrement + erase test", i_colony.size() == 350001)
+		
+
+		for (unsigned int temp = 0; temp != 100000; ++temp)
+		{
+			i_colony.insert(10);
+		}
+		
+		colony<int>::iterator begin_iterator = i_colony.begin() + 2;
+		begin_iterator += 299998;
+		
+		
+		for (colony<int>::iterator the_iterator = begin_iterator; the_iterator != i_colony.end();)
+		{
+			the_iterator = i_colony.erase(the_iterator);
+		}
+		
+		FAILPASS("Non-beginning increment + erase test", i_colony.size() == 300000)
+		
+		for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
+		{
+			the_iterator = i_colony.erase(the_iterator);
+		}
+		
+		FAILPASS("Final erase test", i_colony.empty())
+		
+		
+		i_colony.reinitialize(3);
+
+		unsigned int count = 0;
+
+		for (unsigned int loop1 = 0; loop1 != 50000; ++loop1)
+		{
+			for (unsigned int loop = 0; loop != 10; ++loop)
+			{
+				if (rand() % 5 == 0)
+				{
+					i_colony.insert(1);
+					++count;
+				}
+			}
+
+			for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
+			{
+				if (rand() % 5 == 0)
+				{
+					the_iterator = i_colony.erase(the_iterator);
+					--count;
+				}
+				else
+				{
+					++the_iterator;
+				}
+			}
+		}
+		
+		FAILPASS("Multiple sequential small insert/erase commands test", count == i_colony.size())
+		
+	}
+
+
+
+	{
+		TITLE1("Stack Tests")
+
+		stack<unsigned int> i_stack(50);
+		
+		for (unsigned int temp = 0; temp != 250000; ++temp)
+		{
+			i_stack.push(10);
+		}
+		
+		FAILPASS("Multipush test", i_stack.size() == 250000)
+		
+		stack<unsigned int> i_stack2 = i_stack;
+		stack<unsigned int> i_stack3(i_stack);
+		
+		FAILPASS("Copy test", i_stack2.size() == 250000)
+		FAILPASS("Copy constructor test", i_stack3.size() == 250000)
+
+		FAILPASS("Equality operator test", i_stack == i_stack2);
+		FAILPASS("Equality operator test 2", i_stack2 == i_stack3);
+		
+		
+		unsigned int total = 0;
+		
+		for (unsigned int temp = 0; temp != 200000; ++temp)
+		{
+			total += i_stack.back();
+			i_stack.pop();
+		}
+
+		FAILPASS("Multipop test", i_stack.size() == 50000)
+		FAILPASS("Back() test", total == 2000000)
+
+		do
+		{
+			if (rand() % 5 == 0)
+			{
+				i_stack.push(10);
+			}
+			else
+			{
+				i_stack.pop();
+			}
+		} while (!i_stack.empty());
+		
+		FAILPASS("Randomly pop/push till empty test", i_stack.size() == 0)
+	}
+
+	}
+
+	TITLE1("Test Suite PASS - Press ENTER to Exit")
+	cin.get();
+
+	return 0;
+}
 
 }


### PR DESCRIPTION
2015-10-4: v2.21 Improved gcc x64 iteration. std::find now working with reverse_iterator. reverse_iterator function corrections, performance improvements. Hintless allocators under C++11 now supported. Allocation now uses allocator_traits under C++11.

2015-9-30: v2.13 - Fixed performance regression with small scalar types and MS VCC. Small bugfixes. Return type for iterator +/- iterator changed to long long int. Small performance things.

2015-9-28: v2.12 - Added const_iterator, const_reverse_iterator, .cbegin, .cend, .crbegin, .crend. Some small bugfixes.

2015-9-27: v2.00 - Larger performance improvements, particularly for small scalar type storage. Corrections to exception handling and EBCO. ".insert" replaces ".add" (realised there is precedence for non-position-based insert via unordered_map/unordered_set). Added postfix iterator increment and decrement. Zero-argument ".add()" and ".push()" function overloads removed (same thing achievable with "colony.insert(the_type());" and "stack.push(the_type());". Many bugfixes and general code cleanup.