### PR TITLE
v3.03

### DIFF
--- a/Docs/plf_nanotimer readme.txt
+++ b/Docs/plf_nanotimer readme.txt
@@ -1,0 +1,38 @@
+plf::nanotimer is a ~nanosecond-precision cross-platform (linux/bsd/mac/windows, C++03/C++11) simple timer class.
+
+Usage is as follows:
+
+{
+	plf::nanotimer timer;
+
+
+	timer.start()
+	// Do something here
+	double results = timer.get_elasped_ns();
+	std::cout << "Timing: " << results << " nanoseconds." << std::endl;
+	
+
+	timer.start(); // "start" has the same semantics as "restart".
+	// Do something else
+	results = timer.get_elasped_ms();
+	std::cout << "Timing: " << results << " milliseconds." << std::endl;
+
+	
+	timer.start()
+	plf::microsecond_delay(15); // Delay program for 15 microseconds
+	results = timer.get_elasped_us();
+	std::cout << "Timing: " << results << " microseconds." << std::endl;
+}	
+
+
+Timer functions:
+timer.start(): start or restart timer
+double timer.get_elasped_ns(): get elapsed time in nanoseconds
+double timer.get_elasped_us(): get elapsed time in microseconds
+double timer.get_elasped_ms(): get elapsed time in milliseconds
+
+
+Free-standing functions:
+plf::millisecond_delay(double x): delay the program until x milliseconds have passed
+plf::microseconds_delay(double x): delay the program until x microseconds have passed
+plf::nanoseconds_delay(double x): delay the program until x nanoseconds have passed

--- a/Docs/plflib documentation - local cached copy - may become out of date/colony.htm
+++ b/Docs/plflib documentation - local cached copy - may become out of date/colony.htm
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-<a href="index.htm">Home</a>
+<a href="index.htm">Home</a> 
 
 <h1>PLF C++ Library - plf::colony</h1>
 <ul>
@@ -47,20 +47,22 @@ non-erased elements (which makes programming with containers of interrelated
 data structures faster and much easier), and broad cross-compiler support.</p>
 
 <p>As it was initially developed predominantly for game development, Colony
-emphasises small and large struct/class performance over scalar-type (float, int,
-etc) performance. As of v3.0, Colony uses a <a
-href="jump_counting_skipfield_pattern.htm">jump-counting skipfield</a> instead of a
-boolean field, which mitigates performance degradation in worst-case iteration
-scenarios ie. large consecutive blocks of erased elements.</p>
+emphasises small and large struct/class performance over scalar-type (float,
+int, etc) performance. As of v3.0, Colony uses a <a
+href="jump_counting_skipfield_pattern.htm">jump-counting skipfield</a> instead
+of a boolean field, which mitigates performance degradation in worst-case
+iteration scenarios ie. large consecutive blocks of erased elements.</p>
 
 <h2><a id="details"></a>Details</h2>
 
-<p>plf::colony uses a <a href="size_doubling_memory_block_allocation.htm">size-doubling memory-block allocation model</a>, utilizing doubly-linked chains of element "groups"
-(memory blocks with additional structure metadata and a jump-counting skipfield),
-removing the need for data reallocation. Because data is not reallocated, all
-references/pointers/iterators to container elements will stay valid regardless
-of erasures and insertions to the containers. Here is how the storage mechanism
-differs from a std::vector:</p>
+<p>plf::colony uses a <a
+href="size_doubling_memory_block_allocation.htm">size-doubling memory-block
+allocation model</a>, utilizing doubly-linked chains of element "groups"
+(memory blocks with additional structure metadata and a jump-counting
+skipfield), removing the need for data reallocation. Because data is not
+reallocated, all references/pointers/iterators to container elements will stay
+valid regardless of erasures and insertions to the containers. Here is how the
+storage mechanism differs from a std::vector:</p>
 <img src="vector_addition.gif"
 alt="Visual demonstration of inserting to a full vector" height="540"
 width="960"> <img src="colony_addition.gif"
@@ -71,11 +73,11 @@ width="960">
 between 1x-4x faster than adding to a std::vector (variability based on element
 sizeof and amount of elements). </p>
 
-<p>Colony has two other internal mechanisms: one is the jump-counting skipfield,
-utilising a 16-bit integer corresponding to every element in the container, and
-enabling the colony to skip over erased elements during iteration. The second
-is a plf::stack of erased element locations which can be reused. When an
-element is erased in a std::vector, the following happens:</p>
+<p>Colony has two other internal mechanisms: one is the jump-counting
+skipfield, utilising a 16-bit integer corresponding to every element in the
+container, and enabling the colony to skip over erased elements during
+iteration. The second is a plf::stack of erased element locations which can be
+reused. When an element is erased in a std::vector, the following happens:</p>
 <img src="vector_erasure.gif"
 alt="Visual demonstration of randomly erasing from a vector" height="540"
 width="960"> 
@@ -83,7 +85,7 @@ width="960">
 <p>But when an element is erased in a colony, this happens:</p>
 <img src="colony_erasure.gif"
 alt="Visual demonstration of randomly erasing from a colony" height="540"
-width="960">
+width="960"> 
 
 <p>This explains the 20x-40000x speed-up you get when erasing from a colony
 (variability based on element sizeof and amount of elements) versus erasing
@@ -139,25 +141,32 @@ restrictions:</p>
 
 <h2><a id="download"></a>Download</h2>
 
-<p>Version 3 under development. Downloads disabled for the moment.<br>
-<!-- <p>Download <a href="plf_colony_20-11-2015.zip">here</a>. (21kb)<br> -->
+<p>Download <a href="plf_colony_24-03-2015.zip">here</a>. (30kb)<br>
 The colony library is a simple .h header file, to be included with a #include
 command. The package includes the plf::stack .h file, which is used internally
 by plf::colony.</p>
 
 <h3>Version history</h3>
 <ul>
-  <li>2015-11-20: v3.00 - Colony now uses a <a
-    href="jump_counting_skipfield_pattern.htm">jump-counting skipfield</a> instead of a
-    boolean field, which mitigates worst-case scenario performance by factors
-    of ten. Iterators now bidirectional instead of random-access, and compliant
-    with C++-specification's time-complexity requirements (all operations O(1)
-    amortised). There is greater compliance with allocators in general. Group
-    size now limited to 65535 max for colony, to decrease memory wastage and
-    improve skipfield performance. Various bugfixes and corrections to
-    oversights. plf::stack storage limit no longer 32-bit uint max (relies on
-    allocator to supply correct size_type). Added std::stack comparison to
-    plf::stack benchmark.</li>
+  <li>2016-03-26: v3.03 - Correction to operator = on colony. Replaced SDL2/SDL_Timer in benchmarks with plf_nanotimer, a cross-platform ~nanosecond-precision timer. Correction to end() and begin() overloads - internal begin/end iterator could previously be altered by user activity, in some cases. Correction to .next functions.</li>
+  <li>2016-03-24: v3.02 - Small performance improvements. Fix for demo for
+    regular SDL2 usage. Duplication of macros from plf_stack.h to plf_colony.h
+    to fix issue when plf_stack.h is also used within project separately from
+    plf_colony.h. </li>
+  <li>2016-02-23: v3.01 - Colony now uses a <a
+    href="jump_counting_skipfield_pattern.htm">jump-counting skipfield</a>
+    instead of a boolean field, which mitigates worst-case scenario performance
+    by factors of ten. Iterators now bidirectional (but include &gt; &lt; &gt;=
+    and &lt;= operators) instead of random-access, and compliant with
+    C++-specification's time-complexity requirements (all operations O(1)
+    amortised). +=, -=, - and + iterator operators relegated to advance,
+    distance, next and prev functions under colony. There is greater compliance
+    with allocators. Group size now limited to 65535 max for colony, to
+    decrease memory wastage and improve skipfield performance. Various bugfixes
+    and corrections. plf::stack storage limit no longer 32-bit uint max (relies
+    on allocator to supply correct size_type). Added worst-case and best-case
+    scenario tests to colony benchmark, and added std::stack comparison to
+    plf::stack benchmark. Benchmarks yet to be updated in docs.</li>
   <li>2015-11-20: v2.34 - Correction to clear() and reinitialize()
   functions.</li>
   <li>2015-11-17: v2.33 - Minor bugfix for GCC versions &lt; 5.</li>
@@ -252,7 +261,7 @@ by plf::colony.</p>
 
 <h2><a id="benchmarks"></a>Benchmarks</h2>
 
-<p style="font-size: 75%"><i>Last updated 6-10-2015 v2.24</i></p>
+<p style="font-size: 75%"><i>Last updated 24-3-2016 v3.02</i></p>
 
 <p>All of the benchmarks below are included in the plf_demo.cpp in the
 download, anyone can run them. They do not require any external libraries.</p>
@@ -261,7 +270,9 @@ download, anyone can run them. They do not require any external libraries.</p>
 much the same on other Intel x64 platforms. Compilers are mingw TDM GCC 5.1
 (both 32-bit and 64-bit versions), MS VC++2010 and MS VC++2013. I've forgone
 clang as the results were much the same as GCC. Release compilation settings
-only, settings for MS compilers are "/O2 /Oi /Ot /Oy /GL /GS- /GY- /arch:SSE2 /MT", for GCC they are "-O2;-march=native;-std=c++11". <a href="http://www.libsdl.org">SDL</a> was used for more precise timing.</p>
+only, settings for MS compilers are "/O2 /Oi /Ot /Oy /GL /GS- /GY- /arch:SSE2
+/MT", for GCC they are "-O2;-march=native;-std=c++11". <a
+href="http://www.libsdl.org">SDL</a> was used for more precise timing.</p>
 
 <h3>Real-world Object-Oriented tests</h3>
 
@@ -304,54 +315,62 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
     </tr>
     <tr>
       <td>std::vector (of pointers to dynamically-allocated objects)</td>
-      <td>176</td>
-      <td>174</td>
-      <td>194</td>
-      <td>195</td>
+      <td>179</td>
+      <td>173</td>
+      <td>213</td>
+      <td>197</td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>54</td>
-      <td>48</td>
-      <td>76</td>
-      <td>66<br>
+      <td>53</td>
+      <td>51</td>
+      <td>77</td>
+      <td>67<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::list</td>
-      <td>186</td>
+      <td>199</td>
       <td>189</td>
-      <td>193</td>
-      <td>195<br>
+      <td>207</td>
+      <td>198<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::map</td>
-      <td>383</td>
-      <td>379</td>
-      <td>444</td>
+      <td>392</td>
+      <td>390</td>
+      <td>445</td>
       <td>408<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque (of pointers to dynamically-allocated objects)</td>
-      <td>173</td>
-      <td>167</td>
-      <td>216</td>
-      <td>237<br>
+      <td>188</td>
+      <td>166</td>
+      <td>241</td>
+      <td>246<br>
       </td>
       <td></td>
     </tr>
     <tr>
+      <td>std::multiset</td>
+      <td>2279</td>
+      <td>2429</td>
+      <td>2482</td>
+      <td>2681</td>
+      <td></td>
+    </tr>
+    <tr>
       <td>colony vs vector performance</td>
-      <td>3.3x</td>
-      <td>3.6x</td>
-      <td>2.6x</td>
-      <td>3.0x<br>
+      <td>3.4x</td>
+      <td>3.4x</td>
+      <td>2.8x</td>
+      <td>2.9x<br>
       </td>
       <td>3.1x<br>
       </td>
@@ -379,17 +398,17 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
     </tr>
     <tr>
       <td>std::vector (as above)</td>
-      <td>318</td>
-      <td>1041</td>
-      <td>334</td>
-      <td>1047<br>
+      <td>310</td>
+      <td>1062</td>
+      <td>300</td>
+      <td>1057<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>32</td>
-      <td>25</td>
+      <td>27</td>
+      <td>27</td>
       <td>40</td>
       <td>29<br>
       </td>
@@ -397,39 +416,47 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
     </tr>
     <tr>
       <td>std::list</td>
-      <td>30</td>
       <td>31</td>
-      <td>43</td>
+      <td>32</td>
+      <td>44</td>
       <td>36<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::map</td>
-      <td>93</td>
-      <td>103</td>
       <td>92</td>
-      <td>93<br>
+      <td>94</td>
+      <td>106</td>
+      <td>107<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque (as above)</td>
-      <td>173</td>
-      <td>336</td>
-      <td>929</td>
-      <td>1519<br>
+      <td>178</td>
+      <td>345</td>
+      <td>878</td>
+      <td>1501<br>
       </td>
       <td></td>
     </tr>
     <tr>
+      <td>std::multiset</td>
+      <td>227</td>
+      <td>266</td>
+      <td>284</td>
+      <td>257</td>
+      <td></td>
+    </tr>
+    <tr>
       <td>colony vs vector performance</td>
-      <td>9.9x</td>
-      <td>41.6x</td>
-      <td>8.4x</td>
-      <td>36.1x<br>
+      <td>11.5x</td>
+      <td>39.3x</td>
+      <td>7.5x</td>
+      <td>36.5x<br>
       </td>
-      <td>24.0x<br>
+      <td>23.7x<br>
       </td>
     </tr>
   </tbody>
@@ -455,53 +482,61 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
     </tr>
     <tr>
       <td>std::vector (as above)</td>
-      <td>1579</td>
-      <td>2099</td>
-      <td>1520</td>
-      <td>2103<br>
+      <td>1593</td>
+      <td>2101</td>
+      <td>1523</td>
+      <td>2107<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>1158</td>
-      <td>1446</td>
-      <td>1204</td>
-      <td>1492<br>
+      <td>1213</td>
+      <td>1461</td>
+      <td>1195</td>
+      <td>1460<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::list</td>
-      <td>1953</td>
-      <td>2824</td>
-      <td>1961</td>
-      <td>2851<br>
+      <td>1972</td>
+      <td>2805</td>
+      <td>1957</td>
+      <td>2833<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::map</td>
-      <td>5564</td>
-      <td>6348</td>
-      <td>5521</td>
-      <td>6186<br>
+      <td>5424</td>
+      <td>6277</td>
+      <td>5842</td>
+      <td>6025<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque (as above)</td>
-      <td>1615</td>
-      <td>2109</td>
-      <td>1724</td>
-      <td>2509<br>
+      <td>1637</td>
+      <td>2111</td>
+      <td>1731</td>
+      <td>2503<br>
       </td>
       <td></td>
     </tr>
     <tr>
+      <td>std::multiset</td>
+      <td>22356</td>
+      <td>24217</td>
+      <td>19853</td>
+      <td>20840</td>
+      <td></td>
+    </tr>
+    <tr>
       <td>colony vs vector performance</td>
+      <td>1.3x</td>
       <td>1.4x</td>
-      <td>1.5x</td>
       <td>1.3x</td>
       <td>1.4x</td>
       <td>1.4x<br>
@@ -530,55 +565,63 @@ with std::list and std::map, both of which satisfy the requirements above.</p>
     <tr>
       <td>std::vector (as above)</td>
       <td>80</td>
-      <td>52</td>
-      <td>63</td>
+      <td>51</td>
+      <td>64</td>
       <td>53<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>5</td>
-      <td>6</td>
-      <td>5</td>
+      <td>9</td>
+      <td>7</td>
+      <td>9</td>
       <td>6</td>
       <td></td>
     </tr>
     <tr>
       <td>std::list</td>
-      <td>101</td>
-      <td>86</td>
+      <td>103</td>
+      <td>75</td>
       <td>92</td>
-      <td>88<br>
+      <td>74<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::map</td>
+      <td>131</td>
       <td>137</td>
-      <td>141</td>
-      <td>145</td>
-      <td>153<br>
+      <td>131</td>
+      <td>163<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque (as above)</td>
-      <td>100</td>
-      <td>89</td>
-      <td>117</td>
-      <td>125<br>
+      <td>101</td>
+      <td>87</td>
+      <td>114</td>
+      <td>119<br>
       </td>
       <td></td>
     </tr>
     <tr>
+      <td>std::multiset</td>
+      <td>289</td>
+      <td>309</td>
+      <td>335</td>
+      <td>317</td>
+      <td></td>
+    </tr>
+    <tr>
       <td>colony vs vector performance</td>
-      <td>16.0x</td>
-      <td>8.7x</td>
-      <td>12.6x</td>
+      <td>8.9x</td>
+      <td>7.3x</td>
+      <td>7.1x</td>
       <td>8.8x<br>
       </td>
-      <td>11.5x<br>
+      <td>8.0x<br>
       </td>
     </tr>
   </tbody>
@@ -630,42 +673,42 @@ destruct objects during this process.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>331</td>
-      <td>310</td>
-      <td>432</td>
-      <td>497</td>
+      <td>354</td>
+      <td>340</td>
+      <td>457</td>
+      <td>525</td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>132</td>
-      <td>123</td>
-      <td>189</td>
-      <td>164</td>
+      <td>133</td>
+      <td>130</td>
+      <td>190</td>
+      <td>167</td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>128</td>
-      <td>115</td>
-      <td>134</td>
+      <td>125</td>
+      <td>117</td>
+      <td>133</td>
       <td>121</td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque</td>
-      <td>172</td>
-      <td>168</td>
-      <td>522</td>
-      <td>504</td>
+      <td>169</td>
+      <td>171</td>
+      <td>523</td>
+      <td>532</td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>2.5x</td>
-      <td>2.5x</td>
-      <td>2.3x</td>
-      <td>3.0x</td>
+      <td>2.7x</td>
+      <td>2.6x</td>
+      <td>3.1x</td>
+      <td>3.1x</td>
       <td>2.6x</td>
     </tr>
   </tbody>
@@ -691,48 +734,48 @@ destruct objects during this process.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>68</td>
-      <td>55</td>
-      <td>98</td>
-      <td>68<br>
+      <td>67</td>
+      <td>60</td>
+      <td>97</td>
+      <td>70<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>78</td>
-      <td>72</td>
-      <td>106</td>
-      <td>77<br>
+      <td>67</td>
+      <td>64</td>
+      <td>99</td>
+      <td>73<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>67</td>
-      <td>54</td>
+      <td>65</td>
+      <td>62</td>
       <td>99</td>
-      <td>67<br>
+      <td>68<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque</td>
-      <td>69</td>
-      <td>58</td>
+      <td>68</td>
+      <td>63</td>
       <td>106</td>
-      <td>74<br>
+      <td>76<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>0.87x</td>
-      <td>0.76x</td>
-      <td>0.92x</td>
-      <td>0.88x<br>
+      <td>1.0x</td>
+      <td>0.94x</td>
+      <td>0.98x</td>
+      <td>0.96x<br>
       </td>
-      <td>0.86x<br>
+      <td>0.97x<br>
       </td>
     </tr>
   </tbody>
@@ -758,46 +801,46 @@ destruct objects during this process.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>2760</td>
-      <td>3540</td>
-      <td>2885</td>
-      <td>3554<br>
+      <td>2733</td>
+      <td>3511</td>
+      <td>2927</td>
+      <td>3587<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>2924</td>
-      <td>3646</td>
-      <td>3059</td>
-      <td>3698<br>
+      <td>3003</td>
+      <td>3686</td>
+      <td>3045</td>
+      <td>3702<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>2783</td>
-      <td>3518</td>
-      <td>2914</td>
-      <td>3488<br>
+      <td>2733</td>
+      <td>3499</td>
+      <td>2931</td>
+      <td>3533<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>std::deque</td>
-      <td>2920</td>
-      <td>3823</td>
-      <td>4302</td>
-      <td>5404<br>
+      <td>2883</td>
+      <td>3813</td>
+      <td>4381</td>
+      <td>5456<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>0.94x</td>
-      <td>0.97x</td>
-      <td>0.94x</td>
-      <td>0.96x<br>
+      <td>0.91x</td>
+      <td>0.95x</td>
+      <td>0.96x</td>
+      <td>0.97x<br>
       </td>
       <td>0.95x<br>
       </td>
@@ -852,39 +895,39 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>337</td>
-      <td>311</td>
-      <td>432</td>
-      <td>496<br>
+      <td>356</td>
+      <td>340</td>
+      <td>457</td>
+      <td>526<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>143</td>
-      <td>122</td>
-      <td>180</td>
-      <td>165<br>
+      <td>142</td>
+      <td>132</td>
+      <td>190</td>
+      <td>167<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>129</td>
-      <td>115</td>
-      <td>133</td>
+      <td>126</td>
+      <td>116</td>
+      <td>135</td>
       <td>121<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>2.4x</td>
+      <td>2.5x</td>
       <td>2.6x</td>
-      <td>2.3x</td>
-      <td>3.0x<br>
+      <td>2.4x</td>
+      <td>3.2x<br>
       </td>
-      <td>2.6x<br>
+      <td>2.7x<br>
       </td>
     </tr>
   </tbody>
@@ -912,38 +955,38 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>37689</td>
-      <td>45834</td>
-      <td>38289</td>
-      <td>45743<br>
+      <td>39462</td>
+      <td>46132</td>
+      <td>37762</td>
+      <td>47657<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>78</td>
-      <td>65</td>
-      <td>102</td>
-      <td>82<br>
+      <td>67</td>
+      <td>67</td>
+      <td>106</td>
+      <td>83<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>67</td>
-      <td>55</td>
+      <td>66</td>
+      <td>61</td>
       <td>97</td>
-      <td>68<br>
+      <td>69<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>483x</td>
-      <td>705x</td>
-      <td>375x</td>
-      <td>557x</td>
-      <td>530x<br>
+      <td>588x</td>
+      <td>688x</td>
+      <td>356x</td>
+      <td>574x</td>
+      <td>552x<br>
       </td>
     </tr>
   </tbody>
@@ -971,39 +1014,39 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>3032</td>
-      <td>3517</td>
-      <td>2950</td>
-      <td>3837<br>
+      <td>3038</td>
+      <td>3537</td>
+      <td>2939</td>
+      <td>3773<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>2906</td>
-      <td>3614</td>
-      <td>3037</td>
-      <td>3939<br>
+      <td>3046</td>
+      <td>3705</td>
+      <td>3014</td>
+      <td>4183<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>2751</td>
+      <td>2775</td>
       <td>3485</td>
-      <td>2895</td>
-      <td>3495<br>
+      <td>2900</td>
+      <td>3486<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>1.04x</td>
-      <td>0.97x</td>
-      <td>0.97x</td>
-      <td>0.97x<br>
+      <td>1.0x</td>
+      <td>0.96x</td>
+      <td>0.98x</td>
+      <td>0.90x<br>
       </td>
-      <td>0.99x<br>
+      <td>0.96x<br>
       </td>
     </tr>
   </tbody>
@@ -1036,27 +1079,27 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>310</td>
-      <td>269</td>
-      <td>442</td>
+      <td>314</td>
+      <td>273</td>
+      <td>445</td>
       <td>464<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>96</td>
-      <td>103</td>
-      <td>99</td>
-      <td>104<br>
+      <td>98</td>
+      <td>105</td>
+      <td>100</td>
+      <td>105<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>94</td>
-      <td>102</td>
       <td>95</td>
+      <td>102</td>
+      <td>96</td>
       <td>101<br>
       </td>
       <td></td>
@@ -1066,7 +1109,7 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
       <td>3.2x</td>
       <td>2.6x</td>
       <td>4.5x</td>
-      <td>4.5x<br>
+      <td>4.4x<br>
       </td>
       <td>3.7x<br>
       </td>
@@ -1096,10 +1139,10 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>7203</td>
-      <td>6235</td>
-      <td>7244</td>
-      <td>7383<br>
+      <td>7178</td>
+      <td>6451</td>
+      <td>8183</td>
+      <td>6024<br>
       </td>
       <td></td>
     </tr>
@@ -1107,28 +1150,27 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
       <td>plf::colony</td>
       <td>&lt; 1</td>
       <td>1</td>
+      <td>&lt; 1</td>
       <td>1</td>
-      <td>&lt; 1<br>
-      </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
       <td>&lt; 1</td>
       <td>&lt; 1</td>
-      <td>&lt; 1</td>
+      <td>1</td>
       <td>&lt; 1<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>&gt; 7203x</td>
-      <td>6235x</td>
-      <td>7244x</td>
-      <td>&gt; 7383x<br>
+      <td>&gt; 7178x</td>
+      <td>6451x</td>
+      <td>&gt; 8183x</td>
+      <td>6024x<br>
       </td>
-      <td>&gt; 7016x<br>
+      <td>&gt; 6959x<br>
       </td>
     </tr>
   </tbody>
@@ -1157,38 +1199,38 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     <tr>
       <td>std::vector</td>
       <td>478</td>
-      <td>480</td>
-      <td>480</td>
-      <td>557<br>
+      <td>482</td>
+      <td>479</td>
+      <td>575<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>516</td>
-      <td>517</td>
-      <td>569</td>
-      <td>659<br>
+      <td>504</td>
+      <td>497</td>
+      <td>495</td>
+      <td>740<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>519</td>
+      <td>521</td>
       <td>531</td>
-      <td>513</td>
-      <td>530<br>
+      <td>515</td>
+      <td>532<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>0.93x</td>
-      <td>0.93x</td>
-      <td>0.84x</td>
-      <td>0.86x<br>
+      <td>0.95x</td>
+      <td>0.97x</td>
+      <td>0.97x</td>
+      <td>0.77x<br>
       </td>
-      <td>0.89x<br>
+      <td>0.92x<br>
       </td>
     </tr>
   </tbody>
@@ -1220,26 +1262,26 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>88</td>
-      <td>76</td>
-      <td>137</td>
-      <td>102<br>
+      <td>89</td>
+      <td>84</td>
+      <td>140</td>
+      <td>113<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>75</td>
-      <td>68</td>
-      <td>130</td>
-      <td>99<br>
+      <td>81</td>
+      <td>80</td>
+      <td>146</td>
+      <td>102<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
       <td>71</td>
-      <td>59</td>
+      <td>65</td>
       <td>103</td>
       <td>72<br>
       </td>
@@ -1247,10 +1289,10 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>1.2x</td>
       <td>1.1x</td>
       <td>1.1x</td>
-      <td>1.0x<br>
+      <td>1.0x</td>
+      <td>1.1x<br>
       </td>
       <td>1.1x<br>
       </td>
@@ -1280,39 +1322,39 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>3771</td>
-      <td>3773</td>
-      <td>3814</td>
-      <td>3810<br>
+      <td>3584</td>
+      <td>3459</td>
+      <td>3632</td>
+      <td>3424<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>74</td>
-      <td>63</td>
-      <td>107</td>
-      <td>78<br>
+      <td>66</td>
+      <td>61</td>
+      <td>108</td>
+      <td>83<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
-      <td>67</td>
-      <td>56</td>
+      <td>66</td>
+      <td>60</td>
       <td>98</td>
-      <td>67<br>
+      <td>69<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>51.0x</td>
-      <td>59.9x</td>
-      <td>35.7x</td>
-      <td>48.9x<br>
+      <td>54.3x</td>
+      <td>56.7x</td>
+      <td>33.6x</td>
+      <td>41.3x<br>
       </td>
-      <td>48.9x<br>
+      <td>46.5x<br>
       </td>
     </tr>
   </tbody>
@@ -1339,39 +1381,39 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
     </tr>
     <tr>
       <td>std::vector</td>
-      <td>1229</td>
-      <td>467</td>
-      <td>458</td>
-      <td>465<br>
+      <td>1230</td>
+      <td>461</td>
+      <td>459</td>
+      <td>2677<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>plf::colony</td>
-      <td>1246</td>
-      <td>978</td>
-      <td>720</td>
-      <td>721<br>
+      <td>1267</td>
+      <td>748</td>
+      <td>1126</td>
+      <td>2766<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>array</td>
       <td>1276</td>
-      <td>686</td>
-      <td>728</td>
-      <td>682<br>
+      <td>674</td>
+      <td>732</td>
+      <td>681<br>
       </td>
       <td></td>
     </tr>
     <tr>
       <td>colony vs vector performance</td>
-      <td>0.99x</td>
-      <td>0.48x</td>
-      <td>0.64x</td>
-      <td>0.65x<br>
+      <td>0.97x</td>
+      <td>0.62x</td>
+      <td>0.41x</td>
+      <td>0.97x<br>
       </td>
-      <td>0.69x<br>
+      <td>0.74x<br>
       </td>
     </tr>
   </tbody>
@@ -1389,54 +1431,57 @@ such as the meaning of using a number in the constructor.</p>
 
 <p></p>
 <ul>
-  <li><code>colony&lt;the_type&gt; a_colony</code>
+  <li><code>colony&lt;the_type&gt; a_colony</code> 
     <p>Default constructor - initial group size is 8. <br>
     Example: <code style="color: brown">plf::colony&lt;int&gt;
     int_colony;</code> </p>
   </li>
   <li><code>colony&lt;the_type, the_allocator&lt;the_type&gt; &gt;
-    a_colony</code>
+    a_colony</code> 
     <p>Default constructor, but using a custom memory allocator eg. something
     other than std::allocator. Custom allocators can also be used with all the
     definitions below, of course. <br>
     Example: <code style="color: brown">plf::colony&lt;int,
     tbb::allocator&lt;int&gt; &gt; int_colony;</code> </p>
   </li>
-  <li><code>colony&lt;the_type&gt; a_colony(const size_type initial_group_size)</code>
-    <p>Directed constructor where the initial group size is defined. Minimum group size is 3. For
-    example if it were 50, the max number of elements in the first colony group
-    would be 50 - the next group would have 100, and so on. Unlike a vector,
-    these 50 elements are not constructed, only the memory is allocated. By
-    default the first group size is 8. A minor performance advantage can be had
-    by using this constructor feature if you know in advance roughly how many
-    objects are likely to be stored in your colony - or at least the rough
-    scale of storage. This would stop many small initial groups being
-    created.<br>
+  <li><code>colony&lt;the_type&gt; a_colony(const size_type
+    initial_group_size)</code> 
+    <p>Directed constructor where the initial group size is defined. Minimum
+    group size is 3. For example if it were 50, the max number of elements in
+    the first colony group would be 50 - the next group would have 100, and so
+    on. Unlike a vector, these 50 elements are not constructed, only the memory
+    is allocated. By default the first group size is 8. A minor performance
+    advantage can be had by using this constructor feature if you know in
+    advance roughly how many objects are likely to be stored in your colony -
+    or at least the rough scale of storage. This would stop many small initial
+    groups being created.<br>
     Example: <code style="color: brown">plf::colony&lt;int&gt;
     int_colony(62);</code></p>
   </li>
   <li><code>colony&lt;the_type&gt; a_colony(const size_type initial_group_size,
-    const size_type maximum_group_size)</code>
+    const size_type maximum_group_size)</code> 
     <p>Like the above this is a directed constructor - the first number sets
     the number of elements in the first group, while the second number sets the
     absolute maximum number of elements any given group may hold ie. Once a
-    group reaches this size, further groups will not increase in size. Minimum initial group size is 3. This
-    could be useful in a scenario where memory is at a premium and where large
-    amounts of erasures are occuring. In that situation, by defining a lower
-    group size you increase the likelihood of any given group becoming empty
-    and hence deallocated and freed to system memory. The maximum size of a
-    colony group is 65535.<br>
+    group reaches this size, further groups will not increase in size. Minimum
+    initial group size is 3. This could be useful in a scenario where memory is
+    at a premium and where large amounts of erasures are occuring. In that
+    situation, by defining a lower group size you increase the likelihood of
+    any given group becoming empty and hence deallocated and freed to system
+    memory. The maximum size of a colony group is 65535.<br>
     Example: <code style="color: brown">plf::colony&lt;int&gt; int_colony(64,
     512);</code></p>
   </li>
-  <li><code>colony&lt;the_type&gt; a_colony(const colony &another_colony)</code>
+  <li><code>colony&lt;the_type&gt; a_colony(const colony
+    &amp;another_colony)</code> 
     <p>Copy constructor - copies all contents from another_colony, removes any
     empty (erased) element spaces. Initial group size is the total size of
     another_colony. <br>
     Example: <code style="color: brown">plf::colony&lt;int&gt;
     int_colony_2(int_colony_1);</code></p>
   </li>
-  <li><code>colony&lt;the_type&gt; a_colony(colony &amp;&amp;another_colony)</code>
+  <li><code>colony&lt;the_type&gt; a_colony(colony
+    &amp;&amp;another_colony)</code> 
     <p>Move constructor - moves all contents from another colony, does not
     remove any erased elements or alter any group sizes. another_colony is now
     void of contents, can be safely destructed. <br>
@@ -1464,44 +1509,50 @@ operator &lt;=<br>
 operator &gt;=<br>
 </code> </p>
 
-<p>All operators have O(1) amortised time-complexity. Originally there were +=, -=, + and - operators, however the time complexity of these varied from O(n) to O(1) depending on the underlying state of the colony, averaging in at O(log n). As such they were not includable in the iterator functions (as per C++ standards). These have been transplanted to colony's advance(), next(), prev() and distance() functions.</p>
+<p>All operators have O(1) amortised time-complexity. Originally there were +=,
+-=, + and - operators, however the time complexity of these varied from O(n) to
+O(1) depending on the underlying state of the colony, averaging in at O(log n).
+As such they were not includable in the iterator functions (as per C++
+standards). These have been transplanted to colony's advance(), next(), prev()
+and distance() functions.</p>
 
 <p>Greater-than/lesser-than usage indicates whether an iterator is higher/lower
 in position compared to another iterator in the same colony (ie. closer to the
 end/beginning).</p>
 
-<p>reverse_iterator and const_reverse_iterator also have the base() command which returns the
-internal iterator.</p>
+<p>reverse_iterator and const_reverse_iterator also have the base() command
+which returns the internal iterator.</p>
 
 <p>Colony contains begin(), end(), rbegin(), rend(), cbegin(), cend(),
-crbegin() and crend() iterator/const_iterator/reverse_iterator/const_reverse_iterator return functions which follow
-standard std:: library rules. Example of usage:</p>
+crbegin() and crend()
+iterator/const_iterator/reverse_iterator/const_reverse_iterator return
+functions which follow standard std:: library rules. Example of usage:</p>
 <code style="color: brown">for (plf::colony&lt;int&gt;::iterator the_iterator =
 data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
 {<br>
-&nbsp;&nbsp;&nbsp;total += *the_iterator;<br>
-}</code>
+   total += *the_iterator;<br>
+}</code> 
 
 <h3>Basic functions</h3>
 <ul>
-  <li><code>iterator insert(const the_type &amp;element)</code>
+  <li><code>iterator insert(const the_type &amp;element)</code> 
     <p>Inserts the element supplied to the colony, using the object's
     copy-constructor. Will insert the element into a previously erased element
-    slot if one exists, otherwise will insert to back of colony. Returns iterator
-    to location of inserted element. Example:</p>
+    slot if one exists, otherwise will insert to back of colony. Returns
+    iterator to location of inserted element. Example:</p>
     <code style="color: brown">plf::colony&lt;unsigned int&gt;
     data_colony(50);<br>
     data_colony.insert(23);</code> </li>
   <li><code>iterator insert(the_type &amp;&amp;element) <b>C++11
-    only</b></code>
+    only</b></code> 
     <p>Moves the element supplied to the colony, using the object's
     move-constructor. Will insert the element in a previously erased element
-    slot if one exists, otherwise will insert to back of colony. Returns iterator
-    to location of inserted element. Example:</p>
+    slot if one exists, otherwise will insert to back of colony. Returns
+    iterator to location of inserted element. Example:</p>
     <p><code style="color: brown">struct just_struct<br>
     {<br>
-    &nbsp;&nbsp;unsigned int number;<br>
-    &nbsp;&nbsp;std::string string1;<br>
+      unsigned int number;<br>
+      std::string string1;<br>
     };<br>
     <br>
     just_struct X;<br>
@@ -1511,120 +1562,176 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
     plf::colony&lt;just_struct&gt; data_colony(50);<br>
     data_colony.insert(std::move(X));</code> </p>
   </li>
-  <li><code>void insert(iterator start_iterator, iterator stop_iterator)</code>
-    <p>Inserts the contents of a colony of the same element type (eg. int, float, a
-    particular class, etcetera) into the given colony. Stops inserting once it
-    reaches the stop_iterator. Example:</p>
+  <li><code>void insert(iterator start_iterator, iterator stop_iterator)</code> 
+    <p>Inserts the contents of a colony of the same element type (eg. int,
+    float, a particular class, etcetera) into the given colony. Stops inserting
+    once it reaches the stop_iterator. Example:</p>
     <code style="color: brown">// Insert all contents of colony2 into
     colony1:<br>
     colony1.insert(colony2.begin(), colony2.end());</code> </li>
-  <li><code>iterator emplace(Arguments ...parameters) <b>C++11 only</b></code>
-    <p>Constructs new element directly within colony. Will insert the element in a previously erased element
-    slot if one exists, otherwise will insert to back of colony. Returns iterator
-    to location of inserted element. "...parameters" are whatever parameters are required
-    by the object's constructor. Example:</p>
+  <li><code>iterator emplace(Arguments ...parameters) <b>C++11 only</b></code> 
+    <p>Constructs new element directly within colony. Will insert the element
+    in a previously erased element slot if one exists, otherwise will insert to
+    back of colony. Returns iterator to location of inserted element.
+    "...parameters" are whatever parameters are required by the object's
+    constructor. Example:</p>
     <p><code style="color: brown">class simple_class<br>
     {<br>
     private:<br>
-    &nbsp;int number;<br>
+     int number;<br>
     public:<br>
-    &nbsp;simple_class(int a_number): number (a_number) {};<br>
+     simple_class(int a_number): number (a_number) {};<br>
     };<br>
     <br>
     plf::colony&lt;simple_class&gt; simple_classes;<br>
     simple_classes.emplace(45); </code> </p>
   </li>
-  <li><code>iterator erase(const iterator &amp;the_iterator)</code>
+  <li><code>iterator erase(const iterator &amp;the_iterator)</code> 
     <p>Removes the element pointed to by the supplied iterator, from the
-    colony. Returns an iterator pointing to the
-    next non-erased element in the colony (or to end() if no more elements are
-    available). This must return an iterator because if a colony group becomes
-    entirely empty, it will be removed from the colony, invalidating the
-    existing iterator. Example of erasure:</p>
+    colony. Returns an iterator pointing to the next non-erased element in the
+    colony (or to end() if no more elements are available). This must return an
+    iterator because if a colony group becomes entirely empty, it will be
+    removed from the colony, invalidating the existing iterator. Example of
+    erasure:</p>
     <code style="color: brown">plf::colony&lt;unsigned int&gt;
     data_colony(50);<br>
     plf::colony&lt;unsigned int&gt;::iterator an_iterator;<br>
     an_iterator = data_colony.insert(23);<br>
     an_iterator = data_colony.erase(an_iterator);</code> </li>
   <li><code>void erase(const iterator &amp;begin_iterator, const iterator
-    &amp;end_iterator)</code>
+    &amp;end_iterator)</code> 
     <p>Erases all contents of a given colony from the begin_iterator to the
     element before the end_iterator. Example:</p>
     <code style="color: brown">plf::colony&lt;int&gt; iterator1 =
     colony1.begin() + 10;<br>
     plf::colony&lt;int&gt; iterator2 = colony1.begin() + 20;<br>
     colony1.erase(iterator1, iterator2);</code> </li>
-   <li><code>bool empty()</code>
-   <p>Returns a boolean indicating whether the colony is currently empty of elements.<br>
-   Example: <code style="color: brown">if (object_colony.empty()) return;</code></p></li>
-   <li><code>void clear()</code>
-   <p>Empties the colony and removes all elements. Deallocates all groups and creates a new starting group of the same size as the original starting group (8, unless specified otherwise by constructor or reinitialize call).<br>
-   Example: <code style="color: brown">object_colony.clear();</code></p></li>
-   <li><code>void reinitialize(const size_type new_size)</code>
-   <p>Clears the colony, creates a new starting group of the size specified.<br>
-   Example: <code style="color: brown">object_colony.reinitialize(1000);</code></p></li>
-   <li><code>void reinitialize(const size_type new_size, const size_type maximum_size)</code>
-   <p>Clears the colony, creates a new starting group of the size specified, with the maximum potential group size set to maximum_size.<br>
-   Example: <code style="color: brown">object_colony.reinitialize(1000, 100000);</code></p></li>
-
-   <li><code>colony & operator = (const colony &amp;source)</code>
-   <p>Copy the elements from another colony to this colony, clearing this colony of existing elements first.<br>
-   Example: <code style="color: brown">// Manually swap data_colony1 and data_colony2 in C++03<br>
+  <li><code>bool empty()</code> 
+    <p>Returns a boolean indicating whether the colony is currently empty of
+    elements.<br>
+    Example: <code style="color: brown">if (object_colony.empty())
+    return;</code></p>
+  </li>
+  <li><code>void clear()</code> 
+    <p>Empties the colony and removes all elements. Deallocates all groups and
+    creates a new starting group of the same size as the original starting
+    group (8, unless specified otherwise by constructor or reinitialize
+    call).<br>
+    Example: <code style="color: brown">object_colony.clear();</code></p>
+  </li>
+  <li><code>void reinitialize(const size_type new_size)</code> 
+    <p>Clears the colony, creates a new starting group of the size
+    specified.<br>
+    Example: <code
+    style="color: brown">object_colony.reinitialize(1000);</code></p>
+  </li>
+  <li><code>void reinitialize(const size_type new_size, const size_type
+    maximum_size)</code> 
+    <p>Clears the colony, creates a new starting group of the size specified,
+    with the maximum potential group size set to maximum_size.<br>
+    Example: <code style="color: brown">object_colony.reinitialize(1000,
+    100000);</code></p>
+  </li>
+  <li><code>colony &amp; operator = (const colony &amp;source)</code> 
+    <p>Copy the elements from another colony to this colony, clearing this
+    colony of existing elements first.<br>
+    Example: <code style="color: brown">// Manually swap data_colony1 and
+    data_colony2 in C++03<br>
     data_colony3 = data_colony1;<br>
     data_colony1 = data_colony2;<br>
-    data_colony2 = data_colony3;</code></p></li>
-   <li><code>colony & operator = (const colony &amp;&amp;source) <b>C++11 only</b></code>
-   <p>Move the elements from another colony to this colony, clearing this colony of existing elements first. Source colony becomes invalid but can be safely destructed without undefined behaviour.<br>
-   Example: <code style="color: brown">// Manually swap data_colony1 and data_colony2 in C++11<br>
-   data_colony3 = std::move(data_colony1);<br>
+    data_colony2 = data_colony3;</code></p>
+  </li>
+  <li><code>colony &amp; operator = (const colony &amp;&amp;source) <b>C++11
+    only</b></code> 
+    <p>Move the elements from another colony to this colony, clearing this
+    colony of existing elements first. Source colony becomes invalid but can be
+    safely destructed without undefined behaviour.<br>
+    Example: <code style="color: brown">// Manually swap data_colony1 and
+    data_colony2 in C++11<br>
+    data_colony3 = std::move(data_colony1);<br>
     data_colony1 = std::move(data_colony2);<br>
-    data_colony2 = std::move(data_colony3);</code></p></li>
-   <li><code>bool operator == (const colony &amp;source)</code>
-   <p>Compare contents of another colony to this colony. Returns a boolean as to whether they are equal.<br>
-   Example: <code style="color: brown">if (object_colony == object_colony2) return;</code></p></li>
-   <li><code>bool operator != (const colony &amp;source)</code>
-   <p>Compare contents of another colony to this colony. Returns a boolean as to whether they are not equal.<br>
-   Example: <code style="color: brown">if (object_colony != object_colony2) return;</code></p></li>
-  <li><code>iterator begin(), iterator end(), const_iterator cbegin(), const_iterator cend()</code>
+    data_colony2 = std::move(data_colony3);</code></p>
+  </li>
+  <li><code>bool operator == (const colony &amp;source)</code> 
+    <p>Compare contents of another colony to this colony. Returns a boolean as
+    to whether they are equal.<br>
+    Example: <code style="color: brown">if (object_colony == object_colony2)
+    return;</code></p>
+  </li>
+  <li><code>bool operator != (const colony &amp;source)</code> 
+    <p>Compare contents of another colony to this colony. Returns a boolean as
+    to whether they are not equal.<br>
+    Example: <code style="color: brown">if (object_colony != object_colony2)
+    return;</code></p>
+  </li>
+  <li><code>iterator begin(), iterator end(), const_iterator cbegin(),
+    const_iterator cend()</code> 
     <p>Return iterators pointing to, respectively, the first element of the
     colony and the element one-past the end of the colony (as per standard STL
     guidelines).</p>
   </li>
-  <li><code>reverse_iterator rbegin(), reverse_iterator rend(), const_reverse_iterator cbegin(), const_reverse_iterator cend()</code>
+  <li><code>reverse_iterator rbegin(), reverse_iterator rend(),
+    const_reverse_iterator cbegin(), const_reverse_iterator cend()</code> 
     <p>Return reverse iterators pointing to, respectively, the last element of
     the colony and the element one-before the first element of the colony (as
     per standard STL guidelines).</p>
   </li>
 </ul>
 
-<h3>iterator/const_iterator/reverse_iterator/const_reverse_iterator functions</h3>
+<h3>iterator/const_iterator/reverse_iterator/const_reverse_iterator
+functions</h3>
 <ul>
-   <li><code>template &lt;class iterator_type, class distance_type&gt;  void advance(iterator_type iterator, distance_type distance)</code>
-   <p>Increments/decrements the iterator supplied by the positive or negative amount indicated by <i>distance</i>. Speed of incrementation will almost always be faster than using the ++ operator on the iterator. In some cases it may approximate O(1).<br>
-   Example: <code style="color: brown">colony&lt;int&gt;::iterator it = i_colony.begin();<br>
-   i_colony.advance(it, 20);
-   </code></p></li>
-   <li><code>template &lt;class iterator_type, class distance_type&gt;  iterator_type next(const iterator_type &iterator, distance_type distance)</code>
-   <p>Creates a copy of the iterator supplied, then increments/decrements this iterator by the positive or negative amount indicated by <i>distance</i>. As above, speed of incrementation will almost always be faster than using the ++ operator on the iterator.<br>
-   Example: <code style="color: brown">colony&lt;int&gt;::iterator it = i_colony.next(i_colony.begin(), 20);</code></p> </li>
-   <li><code>template &lt;class iterator_type, class distance_type&gt;  iterator_type prev(const iterator_type &iterator, distance_type distance)</code>
-   <p>Creates a copy of the iterator supplied, then decrements/increments this iterator by the positive or negative amount indicated by <i>distance</i>. As above, speed of incrementation will almost always be faster than using the ++ operator on the iterator.<br>
-   Example: <code style="color: brown">colony&lt;int&gt;::iterator it2 = i_colony.prev(i_colony.end(), 20);</code></p> </li>
-   <li><code>template &lt;class iterator_type&gt;  std::iterator_traits&lt;iterator_type&gt;::difference_type distance(const iterator_type &first, const iterator_type &last)</code>
-   <p>Measures the distance between two iterators, returning the result, which will be negative if the second iterator supplied is before the first iterator supplied in terms of it's location in the colony.<br>
-   Example: <code style="color: brown">colony&lt;int&gt;::iterator it = i_colony.next(i_colony.begin(), 20);<br>
-   colony&lt;int&gt;::iterator it2 = i_colony.prev(i_colony.end(), 20);<br>
-   std::cout << "Distance: " << i_colony.distance(it, it2) << std::endl;</code></p> </li>
+  <li><code>template &lt;class iterator_type, class distance_type&gt; void
+    advance(iterator_type iterator, distance_type distance)</code> 
+    <p>Increments/decrements the iterator supplied by the positive or negative
+    amount indicated by <i>distance</i>. Speed of incrementation will almost
+    always be faster than using the ++ operator on the iterator. In some cases
+    it may approximate O(1).<br>
+    Example: <code style="color: brown">colony&lt;int&gt;::iterator it =
+    i_colony.begin();<br>
+    i_colony.advance(it, 20); </code></p>
+  </li>
+  <li><code>template &lt;class iterator_type, class distance_type&gt;
+    iterator_type next(const iterator_type &amp;iterator, distance_type
+    distance)</code> 
+    <p>Creates a copy of the iterator supplied, then increments/decrements this
+    iterator by the positive or negative amount indicated by <i>distance</i>.
+    As above, speed of incrementation will almost always be faster than using
+    the ++ operator on the iterator.<br>
+    Example: <code style="color: brown">colony&lt;int&gt;::iterator it =
+    i_colony.next(i_colony.begin(), 20);</code></p>
+  </li>
+  <li><code>template &lt;class iterator_type, class distance_type&gt;
+    iterator_type prev(const iterator_type &amp;iterator, distance_type
+    distance)</code> 
+    <p>Creates a copy of the iterator supplied, then decrements/increments this
+    iterator by the positive or negative amount indicated by <i>distance</i>.
+    As above, speed of incrementation will almost always be faster than using
+    the ++ operator on the iterator.<br>
+    Example: <code style="color: brown">colony&lt;int&gt;::iterator it2 =
+    i_colony.prev(i_colony.end(), 20);</code></p>
+  </li>
+  <li><code>template &lt;class iterator_type&gt;
+    std::iterator_traits&lt;iterator_type&gt;::difference_type distance(const
+    iterator_type &amp;first, const iterator_type &amp;last)</code> 
+    <p>Measures the distance between two iterators, returning the result, which
+    will be negative if the second iterator supplied is before the first
+    iterator supplied in terms of it's location in the colony.<br>
+    Example: <code style="color: brown">colony&lt;int&gt;::iterator it =
+    i_colony.next(i_colony.begin(), 20);<br>
+    colony&lt;int&gt;::iterator it2 = i_colony.prev(i_colony.end(), 20);<br>
+    std::cout "Distance: " i_colony.distance(it, it2) std::endl;</code></p>
+  </li>
 </ul>
 
 <h2><a id="faq"></a>Frequently Asked Questions</h2>
 <ol>
   <li><h4>TLDR, what is a colony?</h4>
     <p>A combination of a linked-list of increasingly-large memory blocks,
-    combined with a jump-counting skipfield, combined with a custom erased-element
-    memory-location stack, resulting in a std::-styled C++ template data
-    container with better performance characteristics for most unordered data
-    in most scenarios.</p>
+    combined with a jump-counting skipfield, combined with a custom
+    erased-element memory-location stack, resulting in a std::-styled C++
+    template data container with better performance characteristics for most
+    unordered data in most scenarios.</p>
   </li>
   <li><h4>Where should it be used in place of the other std:: containers?</h4>
     <p>It should be used, for performance reasons, in any situation where the
@@ -1655,7 +1762,9 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
   <li><h4>What are some examples of situations where a colony strongly improves
     performance?</h4>
     <p>Some ideal situations to use a colony: quadtree, persistent octtree,
-    general game entities or destructible-objects in a video game, anywhere where objects are being created and destroyed continuously such as a particle engine, etc. Also, anywhere where a vector of pointers to
+    general game entities or destructible-objects in a video game, anywhere
+    where objects are being created and destroyed continuously such as a
+    particle engine, etc. Also, anywhere where a vector of pointers to
     dynamically-allocated objects would typically end up being used in order to
     preserve object references.</p>
   </li>
@@ -1672,7 +1781,8 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
     <p>In the case of small primitive types and low amounts of realtime
     insert/erase, you may find a vector faster, although insert/erase are
     always at least factors of ten longer in duration than iteration times,
-    regardless of which container we're discussing. So benchmarking is required.</p>
+    regardless of which container we're discussing. So benchmarking is
+    required.</p>
     <p>Also, as noted, a vector is easier to use when dealing with ordered
     data. You may sort the data in a colony by iterating over it with a
     swapping/sorting function, but you cannot control insertion placement.</p>
@@ -1697,16 +1807,16 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
     with a vector.</p>
   </li>
   <li><h4>Is it similar to a deque?</h4>
-    <p>A deque is fairly dissimilar to a colony. A deque is a double-ended queue,
-    which requires a very different internal framework. It may or may not use a
-    linked-list of memory blocks, dependent on the compiler or implementation,
-    and has no comparable performance characteristics. Deque element erasure performance 
-    varies quite wildly depending on the compiler compared to std::vector, and
-    it does not free unused memory blocks to the OS once they are empty, unlike
-    a colony. In addition a deque invalidates references to subsequent
-    container elements when erasing elements, which a colony does not. A colony
-    never invalidates pointers/iterators to elements unless the element being
-    referred to is erased. </p>
+    <p>A deque is fairly dissimilar to a colony. A deque is a double-ended
+    queue, which requires a very different internal framework. It may or may
+    not use a linked-list of memory blocks, dependent on the compiler or
+    implementation, and has no comparable performance characteristics. Deque
+    element erasure performance varies quite wildly depending on the compiler
+    compared to std::vector, and it does not free unused memory blocks to the
+    OS once they are empty, unlike a colony. In addition a deque invalidates
+    references to subsequent container elements when erasing elements, which a
+    colony does not. A colony never invalidates pointers/iterators to elements
+    unless the element being referred to is erased. </p>
   </li>
   <li><h4>What is it most similar to?</h4>
     <p>A vector, because the performance characteristics are more similar
@@ -1715,7 +1825,10 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
     do.</p>
   </li>
   <li><h4>What are the thread-safe guarantees?</h4>
-  <p>Same as STL, multiple consecutives reads are fine, multiple consecutive writes are not. Somebody can step up and make a write-threadsafe version using atomics if they feel the need.</p>
+    <p>Same as STL, multiple consecutives reads are fine, multiple consecutive
+    writes are not. Somebody can step up and make a write-threadsafe version
+    using atomics if they feel the need.</p>
+  </li>
   <li><h4>Will ordered insert be added to the functions?</h4>
     <p>It would only be possible in a vector implementation using the colony
     architecture, but isn't possible in colony itself. Theoretically, it would
@@ -1740,7 +1853,9 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
     <ol type="a">
       <li>"insert" placement can be at the back, front, or frankly anywhere in
         the container, depending on what's been deleted previously and where it
-        was. Insertion is essentially random unless no erasures have been made prior, or an equal number of erasures and insertions have been made prio.</li>
+        was. Insertion is essentially random unless no erasures have been made
+        prior, or an equal number of erasures and insertions have been made
+        prio.</li>
       <li><code>plf::colony&lt;int&gt; a_colony(500);</code> does not mean the
         same thing as <code>std::vector&lt;int&gt; a_vector(500);</code>. A
         vector inserts 500 elements using the type's default constructor when
@@ -1757,8 +1872,8 @@ data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)<br>
         colony, the memory block the iterator pointed to may no longer exist,
         because, if it were the final remaining element in the memory block,
         the group containing the memory block will have been removed from the
-        colony chain. Erasure of the specific element is the only way that iterators and pointers to a
-        colony element can become invalidated.</li>
+        colony chain. Erasure of the specific element is the only way that
+        iterators and pointers to a colony element can become invalidated.</li>
     </ol>
   </li>
   <li><h4>Any special-case uses?</h4>

--- a/Docs/plflib documentation - local cached copy - may become out of date/jump_counting_skipfield_pattern.htm
+++ b/Docs/plflib documentation - local cached copy - may become out of date/jump_counting_skipfield_pattern.htm
@@ -5,7 +5,7 @@
   <meta name="description"
   content="PLF C++ Library">
   <meta name="keywords"
-  content="C++, C, PLF, colony, stack, STL, containers, optimize, performance, pointer, iterator, jump-counting, boolean, field">
+  content="C++, C, PLF, colony, stack, STL, containers, optimize, performance, pointer, index, iterator, jump-counting, boolean, field">
   <title>PLF C++ Library - The Jump-counting Skipfield Pattern</title>
   <link rel="stylesheet" type="text/css" href="style.css">
 </head>
@@ -23,7 +23,7 @@
 
 <h2>Introduction</h2>
 
-<p>In many areas of computer science, particularly game engines, there exist scenarios where boolean fields are used to to indicate items which are no longer active, as opposed instead to actually erasing and removing these elements, as erasure tends to come with one or more side-effects. Subsequently during iteration and processing this boolean field is checked in order to skip over or ignore the inactive elements. A simple example of this is having a raw array of data for individual objects in a video game, with an additional boolean field called 'active' on each object, and setting the 'active' flag to false when that object is removed from the game. Subsequent to this in terms of iteration, that object would be skipped during processing. The advantages of the technique are (a) with a primitive structure like an array, actual removal of an element from active memory may not be possible, (b) if a more complex structure like a vector is used, actually erasing elements typically causes enormous performance disadvantages, due to reallocation of subsequent elements in order to preserve element contiguousness, which (c) also invalidates pointers to data within the container in question. This last point is of most concern with highly modular or object-oriented code, of which games are largely comprised. To work around these problems the aforementioned active/inactive boolean erasure field is often implemented and pointer/iterator stability is preserved.</p>
+<p>In many areas of computer science, particularly game engines, there exist scenarios where boolean fields are used to to indicate items which are no longer active, as opposed instead to actually erasing and removing these elements, as erasure tends to come with one or more side-effects. Subsequently during iteration and processing this boolean field is checked in order to skip over or ignore the inactive elements. A simple example of this is having a raw array of data for individual objects in a video game, with an additional boolean field called 'active' on each object, and setting the 'active' flag to false when that object is removed from the game. Subsequent to this in terms of iteration, that object would be skipped during processing. The advantages of the technique are (a) with a primitive structure like an array, actual removal of an element from active memory may not be possible, (b) if a more complex structure like a vector is used, actually erasing elements typically causes enormous performance disadvantages, due to reallocation of subsequent elements in order to preserve element contiguousness, which (c) also invalidates pointers to data within the container in question. This last point is of most concern with highly modular or object-oriented code, of which games are largely comprised. To work around these problems the aforementioned active/inactive boolean skipfield is often implemented and pointer/iterator stability is preserved.</p>
 
 <p>This technique is worthwhile, simple, but inefficient for a container with large numbers of consecutive 'inactive' elements, as iteration over these requires checking the boolean fields once for each inactive element, with no ability to simply skip from one 'active' element to the next. A jump-counting skipfield negates the inefficiencies of this approach, without creating significant additional computational overhead. In short, it is a numeric sequence which indicates both when to skip over elements and how many elements to skip over, in any given sequence of data. It is most obviously useful in implementing a pointer-stable/iterator-stable data container, where it can indicate sequences of erased elements to skip over. It may possibly have other applications within computer science. But for the remainder of this document we will discuss the pattern in the context of implementation within a data container (for the purposes of simplicity).</p>
 
@@ -35,51 +35,60 @@
 
 <h3>Basic notation</h3>
 
-<p>The skipfield is always an array of an unsigned integer type. This integer must be sufficiently large to describe the number of elements that can be potentially stored within the memory block it is associated with. For example, a memory block large enough to store 65535 elements would require a skipfield made up of 16-bit unsigned integers. A memory block large enough to store 4294967295 elements would require a skipfield made up of 32-bit unsigned integers. By default all non-erased elements are notated with zero. As an example, if you have a set of ten elements in a memory block, the memory block's corresponding skipfield would look like this:</p>
+<p>The skipfield is always an array of an unsigned integer type. This integer must be sufficiently large to describe the number of elements that can be potentially stored within the memory block it is associated with. For example, a memory block large enough to store 65535 elements would require a skipfield made up of 16-bit unsigned integers. A memory block large enough to store 4294967295 elements would require a skipfield made up of 32-bit unsigned integers. By default all non-erased elements are notated with zero. As an example, if you have a set of ten non-erased elements in a memory block, the memory block's corresponding skipfield (S) would be:</p>
 
-<code>0 0 0 0 0 0 0 0 0 0</code>
+<code>S = (0 0 0 0 0 0 0 0 0 0)</code>
 
 
 <p>A non-zero value indicates erasure.<br>
 If a singular element is erased and has no consecutive erased elements it is notated with a 1:</p>
 
-<code>0 0 0 0 0 1 0 0 0 0</code>
+<code>S = (0 0 0 0 0 1 0 0 0 0)</code>
 
 
-<p>From this point on in the document we will refer to locations within the skipfield as 'nodes' and sequences of consecutively erased elements (as notated in the skipfield) as 'skip blocks'. The first node indicating a skip block (eg. the first '4' in the example below) is called the 'start node'. The last node in that skip block is called the 'end node' (eg. the last '4' in the example below). If two or more consecutive elements are erased, the start node is set to the number of elements which need to be skipped, as is the end node. Below we show a skipfield attached to a data container where the 3rd, 4th, 5th and 6th elements have been erased:</p>
+<p>From this point on in the document we will refer to locations within the skipfield as 'nodes' and sequences of consecutively erased elements (as notated in the skipfield) as 'skipblocks'. Below we show a skipfield attached to a data container where the 3rd, 4th, 5th and 6th elements have been erased. The first node indicating a skipblock (eg. the first '4' in the example below) is called the 'start node'. The last node in that skipblock is called the 'end node' (eg. the last '4' in the example below). If two or more consecutive elements are erased, the start node is set to the number of elements which need to be skipped, as is the end node.</p>
 
-<code>0 0 4 0 0 4 0 0 0 0</code>
+<code>S = (0 0 4 0 0 4 0 0 0 0)</code>
 
 
 
 <h3>Iteration</h3>
 
-<p>To iterate across a memory block utilising using a jump-counting skipfield, an iterator must keep track of both it's current element and the corresponding skipfield node. The node index will always correspond to the element index ie. element[5] is always associated with skipfield[5]. So technically we only need to keep track of the index number (n); however, for performance reasons, we might choose in actual code to keep a pointer to the element array (e) and a pointer to the skipfield (s) instead, depending on circumstance. If we use pointers, to iterate forwards across the elements in the memory block using the skipfield, for every +1 iteration we would:</p>
+<p>To iterate across a set of elements using a jump-counting skipfield to identify inactive and skippable elements, an iterator must keep track of both it's current element and the corresponding skipfield node. The node index will always correspond to the element index ie. element[5] is always associated with skipfield[5]. So technically we only need to keep track of the index number (i); however, for performance reasons, we might choose in actual code to keep a pointer to the element array (e) and a pointer to the skipfield (s) instead, depending on circumstance.</p>
+<p>If we use pointers, to iterate forwards by 1 across the elements in the memory block using the skipfield, we would:</p>
 <ol type='1'>
 <li>increment both the element pointer (e) and the skipfield pointer (s) by one, then</li>
-<li>add the value of the number pointed to by the skipfield pointer (v<sub>s</sub>) to both the element pointer and to the skipfield pointer itself.</li>
+<li>add the value of the number pointed to by the skipfield pointer (*s) to both the element pointer and to the skipfield pointer itself.</li>
 </ol>
 
 <p>ie.</p>
 <code>s = s + 1<br>
-e = e + 1 + V<sub>s</sub><br>
-s = s + V<sub>s</sub></code>
+e = e + 1 + *s<br>
+s = s + *s</code>
 
 <p>Or in C++:</p>
-<code>e += 1 + *(++s);<Br>
+<code>e += 1 + *(++s);<br>
 s += *s;</code>
 
-<p>Alternatively if we only keep track of the index number, we can just:
+<p>Alternatively if we only keep track of the index number, we can just:</p>
 <ol type='1'>
-<li>increment the index number (n) by one, then</li>
-<li>add the value of the number at skipfield index <i>n</i> to <i>n</i> itself.</li>
+<li>increment the index number (i) by one, then</li>
+<li>add the value of the number at skipfield (S) index i (S<sub>i</sub>) to i.</li>
 </ol>
 
-<p>From the rest of the document we will discuss the matter as if we have chosen the pointer approach. In either case the value of the number pointed to in the skipfield pointer is the number of elements to skip on that iteration ie. number of consecutive inactive elements. Some example pseudocode for a single +1 increment of an iterator using pointers:</p>
+<p>ie.</p>
+<code>i = i + 1<br>
+i = i + S<sub>i</sub><br>
+</code>
+
+<p>Or in C++:</p>
+<code>++i;<br>
+i += S[i];</code>
 
 
+<p>In either case the value of the number pointed to, by either a skipfield pointer or an index into the skipfield, is the number of elements to skip on that iteration ie. number of consecutive inactive elements. For the rest of the document we will discuss the matter in terms of the index approach, for simplicity's sake. Here's how iteration looks on the skipfield we demonstrated above:</p>
 
-<p>Here's how iteration looks on the skipfield we demonstrated above - we will ignore the element pointer in this example:</p>
+<p><i>(Notes: in all examples, </i>|<i> is the node indicated by the current index number. Index enumeration starts from 1, to make the examples more straightforward, rather than from 0, as it would be implemented in most languages. Lastly, we will skip the S = () array notation for all subsequent examples, for the purposes of visual clarity.)</i></p>
 
 
 <h5>Before incrementing:</h5>
@@ -89,39 +98,48 @@ s += *s;</code>
 |<br>
 0 0 4 0 0 4 0 0 0 0</code>
 
-<p>skipfield_pointer is at skipfield node 0.</p>
-<p>(where '|' is the node pointed to by the current skipfield pointer after operation)</p>
+<p>(i = 1)</p>
+
 
 
 
 <h5>Increment by 1:</h5>
+<p>i = i + 1<br>
+(i = 2, S<sub>i</sub> = 0)<br>
+i = i + S<sub>i</sub><br>
+(i = 2, S<sub>i</sub> = 0)</p>
 
+
+<h5>After incrementing:</h5>
 <code>
 &nbsp;&nbsp;|<br>
 0 0 4 0 0 4 0 0 0 0</code>
-<p>ie. skipfield_pointer = skipfield_pointer + 1<br>
-skipfield_pointer = skipfield_pointer + value_of_number_at(skipfield_pointer) (ie. 0)</p>
 
 
 
 
 <h5>Increment by 1 again:</h5>
+<p>i = i + 1<br>
+(i = 3, S<sub>i</sub> = 4)<br>
+i = i + S<sub>i</sub><br>
+(i = 7, S<sub>i</sub> = 0)</p>
 
+
+<h5>After incrementing again:</h5>
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<Br>
 0 0 4 0 0 4 0 0 0 0</code>
-<p>ie. skipfield_pointer = skipfield_pointer + 1<br>
-skipfield_pointer = skipfield_pointer + value_of_number_at(skipfield_pointer) (ie. 4)</p>
 
 
-
+<br>
+<br>
 <p>Obviously this also works in reverse iteration, in which case you:</p>
 <ol type='1'>
-<li>decrement both the element pointer and skipfield pointer by one, then</li>
-<li>subtract the value of the node pointed to by the skipfield pointer, from both the element pointer and the skipfield pointer.</li>
+<li>decrement the index (i) by one, then</li>
+<li>subtract the value of the skipfield at the index (S[n]) from the index</li>
 </ol>
 
-<p>And once again the second number subtracted is the number of elements skipped in that decrement. Here is the same skipfield pattern while decrementing:</p>
+<p>Once again, the second number subtracted is the number of elements skipped in that decrement. Here is an example using the same skipfield pattern as above:</p>
 
 
 
@@ -130,28 +148,34 @@ skipfield_pointer = skipfield_pointer + value_of_number_at(skipfield_pointer) (i
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 4 0 0 4 0 0 0 0</code>
-<p>ie. skipfield_pointer is at skipfield node 8</p>
+<p>(i = 8)</p>
 
 
-
-
+     
 <h5>Decrement by 1:</h5>
+<p>i = i - 1<br>
+(i = 7, S<sub>i</sub> = 0)<br>
+i = i - S<sub>i</sub><br>
+(i = 7, S<sub>i</sub> = 0)</p>
 
+
+<h5>After decrementing:</h5>
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 4 0 0 4 0 0 0 0</code>
-<p>ie. skipfield_pointer = skipfield_pointer - 1<br>
-skipfield_pointer = skipfield_pointer - value_of_number_at(skipfield_pointer) (ie. 0)</p>
-
-
 
 <h5>Decrement by 1 again:</h5>
+<p>i = i - 1<br>
+(i = 6, S<sub>i</sub> = 4)<br>
+i = i - S<sub>i</sub><br>
+(i = 2, S<sub>i</sub> = 0)</p>
+        
 
+
+<h5>After decrementing again:</h5>
 <code>
 &nbsp;&nbsp;|<br>
 0 0 4 0 0 4 0 0 0 0</code>
-<p>ie. skipfield_pointer = skipfield_pointer - 1<br>
-skipfield_pointer = skipfield_pointer - value_of_number_at(skipfield_pointer) (ie. 4)</p>
 
 
 
@@ -159,11 +183,12 @@ skipfield_pointer = skipfield_pointer - value_of_number_at(skipfield_pointer) (i
 <h3>Erasure</h3>
 
 <p>If an element is erased in a container utilising a jump-counting simple skipfield, we first check the nodes to the left and to the right of the skipfield node corresponding with the element being erased:</p>
+<p><i>(note: </i>*<i> indicates nodes whose values we are assessing)</i></p>
+
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;* | *<br>
 0 0 0 0 0 0 0 0 0 0</code>
 
-<p>(where * indicates nodes whose values we are assessing)</p>
 
 <p>Now, there are four possibilities: either</p>
 <ol type='a'>
@@ -173,12 +198,13 @@ skipfield_pointer = skipfield_pointer - value_of_number_at(skipfield_pointer) (i
 <li>both left and right are non-zero.</li>
 </ol>
 
-<p>Let's examine how all four of those scenarios are treated:</p>
+<p>Let's examine how all four of those scenarios are treated.</p>
 
 
-<h4>Both left and right are zero</h4>
+<h4>Scenario 1: Both left and right are zero</h4>
 
 <p>We set the value of the current skipfield node to 1. This indicates a single element erasure with no consecutive erased elements. No further action is required.</p>
+<p><i>(note: </i>|<i> indicates the skipfield node corresponding to the container element we're erasing)</i></p>
 
 <h5>Before erasure:</h5>
 
@@ -186,6 +212,8 @@ skipfield_pointer = skipfield_pointer - value_of_number_at(skipfield_pointer) (i
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 0 0 0 0 0 0 0 0</code>
 
+<h5>Erasure:</h5>
+<p>S<sub>i</sub> = 1</p>
 
 <h5>After erasure:</h5>
 
@@ -195,104 +223,126 @@ skipfield_pointer = skipfield_pointer - value_of_number_at(skipfield_pointer) (i
 
 
 
-<h5>Only left is non-zero:</h5>
+<h5>Scenario 2: Only left is non-zero:</h5>
 
-<p>If only the number to the left is non-zero, we set the value of the current node to the number to the left, plus one. The current node is now the new "end node" for this skipfield block. We then subtract the number to the left from the current skipfield's index to find the start node, and set the start node to the current node's value. We do not change the value of the node immediately to the left (ie. the prior end node). Eg.:<br>
+<p>If only the left-hand node is non-zero, we set the value of the current node to the value of the left-hand node, plus one. The current node is now the new end node for the preceding skipblock. We then subtract the value of the left-hand node from the current node's index number to find the start node's index number, and set the start node's value to the current node's value. We do not change the value of the left-hand node (ie. the prior end node).<br>
 
 
 <h5>Before erasure:</h5>
-(where '|' indicates the node corresponding to the container element we're erasing)</p>
 
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 0 3 0 3 0 0 0 0</code>
+
+<h5>Erasure:</h5>
+<p>S<sub>i</sub> = 1 + S<sub>i - 1</sub><br> 
+j = i - S<sub>i - 1</sub><Br>
+S<sub>j</sub> = S<sub>i</sub></p>
+
 
 
 <h5>After erasure:</h5>
 
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 0 4 0 3 4 0 0 0</code>
-<p>ie. value_of(current node) = value_of(previous node) (ie. 3) + 1<br>
-value_of(current node - 3) = value_of(current node)</p>
 
 
 
-<h4>Only right is non-zero</h4>
+<h4>Scenario 3: Only right is non-zero</h4>
 
-<p>If only the number to the right is non-zero, we make the current skipfield node the start node of the subsequent skipfield block by making it equal to the number to the right, plus 1. Then we add the number to the right to the index of the current skipfield node to find the end node, and set the value of the end node to be the same as the start node. Eg.:</p>
+<p>If only the right-hand node is non-zero, we make the current node equal to the right-hand node, plus one, and it becomes the start node of the skipblock to the right. We then add the right-hand node value to the current node's index to find the end node, and set the value of the end node to the value of the current node.</p>
 
 <h5>Before erasure:</h5>
 
-<code>&nbsp;&nbsp;&nbsp;|<br>
+<code>&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 0 2 2 0 0 0 0 0</code>
 
+<h5>Erasure:</h5>
+<p>S<sub>i</sub> = 1 + S<sub>i + 1</sub><br>
+j = i + S<sub>i + 1</sub><br>
+S<sub>j</sub> = S<sub>i</sub></p>
 
 
 <h5>After erasure:</h5>
 
-<code>&nbsp;&nbsp;&nbsp;|<br>
+<code>&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 3 2 3 0 0 0 0 0</code>
-<p>ie. value_of(current node) = value_of(next node) (ie. 2) + 1<br>
-value_of(current node + 2) = value_of(current node)</p>
 
 
 
-<h4>Both left and right are non-zero</h4>
 
-<p>If both of the numbers to the right and left are non-zero, we subtract the number to the left from the current skipfield index to find the left-hand start node. We increment the value of that node by 1 plus the value of the number immediately to the right ie. the right-hand start node. We then add the right-hand start node's number to the current skipfield node's index to find the right-hand end node, and then set the right-hand end node's value to the same number as the left-hand start node. Eg.:</p>
+<h4>Scenario 4: Both left and right are non-zero</h4>
+
+<p>If both left-hand and right-hand nodes are non-zero, then the current node is in the middle of two separate skipblocks, one on the left and one on the right. We subtract the left-hand node's value from the current node's index number to find the left skipblock's start node index number. We increment the value of that start node by one plus the value of the current node's right-hand node. Then we add the right-hand node's value to the current node's index number to find the right skipblock's end node index number, and set that end node's value to the same value as the left skipblock's start node.</p>
 
 
 <h5>Before erasure:</h5>
 
-<code>&nbsp;&nbsp;&nbsp;|<br>
+<code>&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 2 2 0 3 0 3 0 0 0 0</code>
+
+<h5>Erasure</h5>
+<p>j = i - S<sub>i - 1</sub><br>
+(j = 3 - 2)<br>
+<br>
+k = i + S<sub>i + 1</sub><br>
+(k = 3 + 3)<br>
+<br>
+S<sub>j</sub> = S<sub>j</sub> + 1 + S<sub>i + 1</sub><br>
+S<sub>k</sub> = S<sub>k</sub> + S<sub>j</sub></p>
 
 
 <h5>After erasure:</h5>
 
-<code>&nbsp;&nbsp;&nbsp;|<br>
+<code>&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 6 2 0 3 0 6 0 0 0 0</code>
 
-<p>ie. start_node = current node - value_of(previous node)<br>
-end_node = current_node + value_of(next node)<br>
-value_of(start_node) = value_of(start_node) (ie. 2) + 1 + value_of(next node) (ie. 3)<br>
-value_of(end_node) = value_of(start_node)</p>
+<h3>Summary</h3>
 
-
-<p>So far, so simple. But this doesn't allow for reusing previously-erased elements, which is where the advanced jump-counting pattern comes in handy. However because it involves slightly fewer calculations than the advanced pattern, the simple pattern could be slightly faster in the use case where reusing memory space is either not useful or not possible.</p>
+<p>All of the simple pattern's principles are reasonably straightforward, but they do not allow for the reuse of previously-erased-element memory space, which is what the advanced pattern facilitates. However, because the simple pattern involves slightly fewer calculations than the advanced pattern, it could be faster in the use case where reuse of memory space is either not useful or not practicable.</p>
 
 
 
 
 <h2>The Advanced Jump-counting Pattern</h2>
 
+<h3>Basic notation</h3>
+<p>This does not differ from the simple pattern, save for the fact that the nodes between the start and end node in a skipblock cannot be zero and instead follow a sequential "plus one" pattern as the example below demonstrates:</p>
+<code>S = (0 0 4 2 3 4 0 0 0 0)</code>
+<p>The formation of this pattern takes place in the erasure section below, while it's purpose becomes apparent in the subsequent restoration or "reuse" section.</p>
+
+<h3>Iteration</h3>
+<p>This does not differ between the simple and advanced patterns, either for increments or decrements.</p>
 
 <h3>Erasure</h3>
 
-<p>The advanced pattern involves slightly more work than the simple pattern, but for the most part the calculations are the same as the simple variant. As in the simple pattern, if an erasure is made to the current element, we check the skipfield nodes to the left and to the right of the node corresponding to the element we want to erase:</p>
-<code>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;* | *<br>
-0 0 0 0 0 0 0 0 0 0</code>
+<p>Erasure for the advanced pattern involves slightly more work than the simple pattern, but for the most part is similar. As in the simple pattern, if an erasure is made to the current element, we check the skipfield nodes to the left and to the right of the node corresponding to the element we want to erase.</p>
 
 
-<h4>Both left and right are zero</h4>
+<h4>Scenario 1: Both left and right are zero</h4>
 
 <p>As with the simple pattern, set the current node's value to 1.</p>
 
 
-<h4>Only left is non-zero</h4>
+<h4>Scenario 2: Only left is non-zero</h4>
 
-<p>If only the left side contains a non-zero number, the procedure is exactly the same as in the simple pattern. We set the value of the current node to the number to the left, plus one. Then we subtract the number to the left from the current node's index to find the start node and set the start node to the same value as the current node.</p>
+<p>If only the left-hand node has a non-zero value, the procedure is exactly the same as in the simple pattern. We set the value of the current node to the value of the left-hand node, plus one. We then subtract the value of the left-hand node from the current node's index number to find the skipblock's start node, then set the start node to the same value as the current node.</p>
 
 
-<h4>Only right is non-zero</h4>
+<h4>Scenario 3: Only right is non-zero</h4>
 
-<p>Here we make the current skipfield node the start node by making it equal to the number immediately to the right, plus one. So far this is the same as the simple pattern. Then we update the values of each subsequent node to the right of the current node, starting from the value of 2 and incrementing once each node, stopping when either a node with a zero value or the end of the skipfield is reached. Eg.:</p>
+<p>Here we make the current node equal to the right-hand node, plus one, and it becomes the start node of the skipblock to the right. So far this is the same as the simple pattern, but now instead of finding the end node and updating it, as we would in the simple pattern, we update the values of each subsequent node to the right of the current node, starting from a value of 2 and incrementing once each node, stopping when either a node with a zero value or the end of the skipfield is reached.</p>
 
 <h5>Before erasure:</h5>
 
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 0 3 2 3 0 0 0 0</code>
+
+<h5>Erasure:</h5>
+<p>S<sub>i</sub> = 1 + S<sub>i + 1</sub><br>
+S<sub>i + 1</sub> = 2<br>
+S<sub>i + 2</sub> = 3<br>
+S<sub>i + 3</sub> = 4</p>
 
 
 <h5>After erasure:</h5>
@@ -301,18 +351,28 @@ value_of(end_node) = value_of(start_node)</p>
 &nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 4 2 3 4 0 0 0 0</code>
 
-<p>You can see that the pattern now essentially brings about an increment-by-one notation after the start node. The reason for this will become apparent later.</p>
+<p>You can see that this pattern brings about an increment-by-one notation after the start node. The reason for this will become apparent later.</p>
 
 
-<h4>Both left and right are non-zero</h4>
+<h4>Scenario 4: Both left and right are non-zero</h4>
 
-<p>Here we subtract the number immediately to the left of the current node from the current node's index to find the left-hand start node index. We increment the value of the left-hand start node by 1 plus the value of the number to the right of the current node ie. the right-hand start node. So far this is the same as the simple pattern. We now set the current node's value to the number immediately to the left of the current node, plus one. We continue to the right, setting the value of the each subsequent node to the previous node's value plus 1, stopping when either a node with a zero value or the end of the skipfield is reached. Eg.:</p>
+<p>Once again there are skipblocks to the left and right of the current node. We subtract the value of the left-hand node from the current node's index number to find the left skipblock's start node index number. We increment this start node by 1 plus the value of the current node's right-hand node. So far this is the same as the simple pattern, but instead updating the end node of the skipblock on the right, we now take the value of the left-hand node, store it (x) and increment it by one. Starting from the current node and continuing to the right, we set every node to x, incrementing x once per node, stopping when either a node with a value of zero or the end of the skipfield is reached.</p>
 
 
 <h5>Before erasure:</h5>
 
 <code>&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 2 2 0 3 2 3 0 0 0 0</code>
+
+
+<h5>Erasure:</h5>
+<p>j = i - S<sub>i - 1</sub><br>
+S<sub>j</sub> = S<sub>j</sub> + 1 + S<sub>i + 1</sub><br>
+x = 1 + S<sub>i - 1</sub><br>
+S<sub>i</sub> = x<br>
+S<sub>i + 1</sub> = x + 1<br>
+S<sub>i + 2</sub> = x + 2<br>
+S<sub>i + 3</sub> = x + 3</p>
 
 
 <h5>After erasure:</h5>
@@ -324,10 +384,9 @@ value_of(end_node) = value_of(start_node)</p>
 
 
 
-<h3>Restoration ie. the reuse of erased element locations</h3>
+<h3>Restoration ie. reuse of erased-element memory</h3>
 
-<p>If we want to insert into the container and at the same time reuse a previously-erased memory location, we need a mechanism for updating the skipfield to reflect this change to the active/inactive status of the container element while simultaeneously keeping the skipfield valid for usage during iteration. Consider the following example: if I want to reuse previously-erased element 4 in a given container, and to indicate this in the skipfield I naively set the element's coorresponding skipfield node to zero, what is going to happen? Let's see:</p>
-
+<p>If we want to insert into the container and reuse a memory location from an element that was previously erased/made inactive, we will need a mechanism for updating the skipfield to reflect this change to the active/inactive status of the container element while simultaneously keeping the skipfield valid for use during iteration. Consider the following example: if I want to reuse previously-erased element 4 in a given container, and to indicate this in the skipfield I naively set the element's corresponding skipfield node to zero, what is going to happen?</p>
 
 <h5>Before reuse of element slot:</h5>
 
@@ -335,7 +394,8 @@ value_of(end_node) = value_of(start_node)</p>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 6 2 3 4 5 6 0 0 0 0</code>
 
-
+<h5>Incorrect reuse:</h5>
+<p>S<sub>i</sub> = 0</p>
 
 <h5>After reuse:</h5>
 
@@ -344,16 +404,24 @@ value_of(end_node) = value_of(start_node)</p>
 6 2 3 0 5 6 0 0 0 0</code>
 
 
-<p>With this result, if you subsequently iterated over the data from the start the 'reused' element slot will be skipped over. And if you started your iteration at at the restored element's location you would end up skipping over non-erased elements. Taking the above result as an example of the latter:</p>
+<p>With this result, if you subsequently iterated over the data from the beginning, the reused element location would be skipped over. And if you began your iteration from the reused element location, you would skip over non-erased elements. Taking the above result, here's an example of the latter:</p>
 
-<h5>Before iteration:</h5>
+<h5>Before increment:</h5>
 
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<Br>
 6 2 3 0 5 6 0 0 0 0</code>
+<p>(i = 4)</p>
+
+<h5>Increment by 1:</h5>
+<p>i = i + 1<br>
+(i = 5)<br>
+i = i + S<sub>i</sub><br>
+(i = 10)</p>
 
 
-<h5>After increment by one:</h5>
+
+<h5>After increment:</h5>
 
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<Br>
@@ -361,24 +429,25 @@ value_of(end_node) = value_of(start_node)</p>
 
 
 
-<p>Obviously this is incorrect. The correct solution is considerably more complex; to update the skipfield properly when restoring elements, we need to do the following. As when erasing, we need to check the values of the skipfield nodes to the left and right of the node corresponding to the erased element whose memory space we want to reuse. eg.:</p>
+<p>Obviously this is incorrect. A correct solution is more complex; to update the skipfield properly when restoring elements, we need to do the following:<br>
+As when erasing, we need to check the values of the skipfield nodes to the left and right of the skipfield node corresponding to the erased element whose memory space we want to reuse. For example:</p>
 
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;* | *<br>
 0 0 0 4 2 3 4 0 0 0</code>
 
 
-<p>Once again we have four possibilities: both left and right node values are zero, left is non-zero and right is zero, left is zero and right is non-zero, both left and right are non-zero. Here's how we deal with those scenarios in the context of reusing memory space:</p>
+<p>Once again we have four possibilities: either both left and right node values are zero, left is non-zero and right is zero, left is zero and right is non-zero, or both left and right are non-zero. Here's how we process those scenarios in the case of reuse:</p>
 
 
-<h4>Both left and right are zero</h4>
+<h4>Scenario 1: Both left and right are zero</h4>
 
 <p>We set the value of the current skipfield to zero. No further updates are necessary.</p>
 
 
 
-<h4>Only left is non-zero</h4>
+<h4>Scenario 2: Only left is non-zero</h4>
 
-<p>If only the left node is non-zero, this indicates the current node is the end node of a skip-block on the left. In this case we take the current node's value, subtract 1 from it, then subtract the resultant number from the current node's index to find the start node of the skip-block. We then set the start node's value to the same current-node-minus-one value. We can then set the current node's value to zero. Eg.:</p>
+<p>If only the left node is non-zero, this indicates the current node is the end node of a skipblock on the left. In this case we take the current node's value and store it (x), subtract 1 from x, then subtract x from the current node's index number to find the index of the skipblock's start node. We then set the start node's value to the same current-node-minus-one value. We can then set the current node's value to zero.</p>
 
 
 <h5>Before reuse:</h5>
@@ -386,6 +455,14 @@ value_of(end_node) = value_of(start_node)</p>
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 0 4 2 3 4 0 0 0</code>
+<p>(i = 7, S<sub>i</sub> = 4)</p>
+
+<h5>Reuse:</h5>
+
+<p>x = S<sub>i</sub> - 1<br>
+j = i - x<br>
+S<sub>j</sub> = x<br>
+S<sub>i</sub> = 0</p>
 
 
 <h5>After reuse:</h5>
@@ -394,21 +471,14 @@ value_of(end_node) = value_of(start_node)</p>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 0 3 2 3 0 0 0 0</code>
 
-<p>ie. start_node = current node - (value_of(current node) (ie. 4) - 1)<br>
-value_of(start_node) = (value_of(current node) - 1)<br>
-value_of(current node) = 0</p>
 
 
-
-
-<p>Another example:</p>
-
-
-<h5>Before reuse:</h5>
+<h5>A different example - before reuse:</h5>
 
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 2 2 0 0 0 0 0 0 0</code>
+<p>(i = 3, S<sub>i</sub> = 2)</p>
 
 
 <h5>After reuse:</h5>
@@ -416,16 +486,14 @@ value_of(current node) = 0</p>
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 1 0 0 0 0 0 0 0 0</code>
-<p>ie. start_node = current node - (2 - 1)<br>
-value_of(start_node) = 2 - 1<br>
-value_of(current node) = 0</p>
 
 
 
 
-<h4>Only right is non-zero</h4>
 
-<p>If only the right node is non-zero, this indicates the current node is the start node of a skip-block continuing to the right. If the value of the current node is two, we set the current node's value to zero and set the value of the node immediately to our right to 1. This is a special case. Eg.:</p>
+<h4>Scenario 3: Only right is non-zero</h4>
+
+<p>If only the right node is non-zero, this indicates the current node is the start node of a skipblock continuing to the right. If the value of the current node is two, we set the current node's value to zero and set the value of the right-hand node to 1. This is a special case. Example:</p>
 
 
 <h5>Before reuse:</h5>
@@ -433,6 +501,10 @@ value_of(current node) = 0</p>
 <code>
 &nbsp;&nbsp;|<br>
 0 2 2 0 0 0 0 0 0 0</code>
+
+<h5>Reuse:</h5>
+<p>S<sub>i</sub> = 0<br>
+S<sub>i + 1</sub> = 1</p>
 
 
 <h5>After reuse:</h5>
@@ -442,7 +514,7 @@ value_of(current node) = 0</p>
 0 0 1 0 0 0 0 0 0 0</code>
 
 
-<p>If the value of the current node is not 2, we set the value of the right-hand node to the value of the current node minus one and set the current node's value to zero. Then, starting from the node after the right-hand node, we update the values of all nodes, starting from the value 2 and incrementing once per node, until we reach either the end of the skipfield or a zero value. . Eg.:</p>
+<p>If the value of the current node is not 2, we set the value of the right-hand node to the value of the current node minus one and set the current node's value to zero. Then, starting from the node after the right-hand node, we update the values of all nodes, starting from the value 2 and incrementing once per node, until we reach either the end of the skipfield or a zero value. Example:</p>
 
 
 <h5>Before reuse:</h5>
@@ -450,6 +522,13 @@ value_of(current node) = 0</p>
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 0 0 0 4 2 3 4 0 0 0</code>
+
+<h5>Reuse:</h5>
+<p>S<sub>i + 1</sub> = S<sub>i</sub> + 1<br>
+S<sub>i</sub> = 0<br>
+S<sub>i + 2</sub> = 2<br>
+S<sub>i + 3</sub> = 3<br>
+</p>
 
 
 
@@ -461,83 +540,94 @@ value_of(current node) = 0</p>
 
 
 
-<h4>Both left and right are non-zero</h4>
+<h4>Scenario 4: Both left and right are non-zero</h4>
 
-<p>Here we combine the procedures for both the 'only left is non-zero' and 'only right is non-zero' scenarios. We take the current node's value, subtract 1 from it, subtract the resultant number (we'll call this "current node value minus one") from the current node's index to find the index of the start node of the skip-block, and store the current value of the start node, which we will now call the "original start node value". We then set the start node's value to our previously calculated "current node value minus one". The left-hand node is now the end node of the left-hand skip block, and is already at it's correct value (there is no need to update it). Eg.:</p>
+<p>In this scenario the current node is inside a skipblock but neither at the beginning nor the end. The end result of the operation will be to split the singular skipblock into two skipblocks. To do so we combine the behaviour for both the 'only left is non-zero' and 'only right is non-zero' scenarios. First we store the current node's value (x), subtract 1 from x, then subtract x from the current node's index number to find the index number of the start node of the skipblock. We then store the current value of the start node (y) and subsequently set it's value to x. The left-hand node is now the end node of the left-hand skipblock, and is already at it's correct value (ie. there is no need to update it).</p>
 
 
-<h5>Before:</h5>
+<h5>Before reuse:</h5>
 
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 6 2 3 4 5 6 0 0 0 0</code>
 
-
-<h5>After:</h5>
+<h5>Reuse (first phase):</h5>
+<p> x = S<sub>i</sub> - 1<br>
+j = i - x<br>
+y = S<sub>j</sub><br>
+S<sub>j</sub> = x</p>
 
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 3 2 3 4 5 6 0 0 0 0</code>
 
 
-<p>We now set the value of the right-hand node to the "original start node value" gathered earlier, minus the value of the current node. Then we set the current node to zero. The right-hand node is now the start node of a new right-hand skip block, thus we have split the original (singular) skip block into two. To continue from the example above, the result is:</p>
+<p>We now set the value of the right-hand node to y minus the value of the current node, and set the current node to zero.</p>
+
+<h5>Reuse (second phase):</h5>
+<p>S<sub>i + 1</sub> = y - S<sub>i</sub><br>
+S<sub>i</sub> = 0</p>
 
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 3 2 3 0 2 6 0 0 0 0</code>
 
-<p>Now, starting from the node after the right-hand node, we update the values of each node, starting with a value of 2 and incrementing by 1 per node, until we either reach the end of the skipfield or a zero value. Obviously if the value of the node after the right-hand node is either zero or beyond the end of the skipfield, no update occurs. Continuing the example above, only a single update would take place, at this point. The end result follows:</p>
+<p>The right-hand node is now the start node of the new right-hand skipblock, thus we have split the original singular skipblock into two. Starting from the node after the right-hand node, we update the values of each node, starting from a value of 2 and incrementing by 1 per node, till we either reach the end of the skipfield or a zero value. Obviously if the value of the node after the right-hand node is either zero or beyond the end of the skipfield, no update occurs. For the example above, only a single update would take place at this point.</p>
+
+<h5>Reuse (third phase):</h5>
+<p>S<sub>i + 2</sub> = 2</p>
+
+<h5>After reuse:</h5>
 
 <code>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|<br>
 3 2 3 0 2 2 0 0 0 0</code>
 
-<p>Restoration of the erased node is complete and the skipfield can be iterated over correctly, both forward and in reverse iteration.</p>
+<p>Reuse of the erased node is complete and the skipfield can be iterated over correctly, both in forward and reverse directions.</p>
 
 
 
 <h2>Performance results</h2>
 
-<p>In C++ performance tests with the colony container, the performance overhead from using the above advanced pattern compared to using a simple boolean field, was close to zero. There was also negligible difference in terms of access and iteration over the container under scenarios with minimal erasures. Some compilers fared better with the boolean erasure field, most fared worse.</p>
-
-<p>However in scenarios with large amounts of consecutive erasures, using the advanced jump-counting pattern improved iteration performance by factor(s) of 10, consistently and across compilers. Below are the test results, using containers of 1000000 small structs, for the scenario where 49 out every 50 consecutive elements was erased, first using a simple boolean field to indicate erasure, then using a jump-counting advanced skipfield. The results were as follows (MSVC 2013, e8500 C2D processor):</p>
+<p>Performance comparisons were performed, across four C++ compilers: GCC 5 32-bit, GCC 5 64-bit, Microsoft Visual Studio 2010 (x86) and Microsoft Visual Studio 2013 (x64). A custom container (plf::colony) using a boolean skipfield to indicate erasure was compared against the same container using a advanced jump-counting skipfield to indicate erasure, and a std::vector. In tests where the number of erasures were low and generally non-consecutive, the performance differences between the jump-counting skipfield colony and the simple boolean skipfield colony were close to zero. Some compilers performed better with the boolean skipfield, most performed worse. But in scenarios with high amounts of consecutive erasures, the colonyt using the advanced jump-counting pattern improved iteration performance by factors of 10, consistently and across compilers. Below are the test results for one of these tests, utilising containers of 1000000 small structs, and erasing 49 out every 50 consecutive elements (Microsoft Visual Studio 2013, standard x64 release settings, e8500 C2D processor):</p>
 
 
 
-<h4>Duration to insert 1000000 small structs with an integer member, into container</h4>
+<h5>Duration to insert 1000000 small structs with an integer member, into container</h5>
 
 <p>
-Vector: 113ms<br>
-Colony with boolean erasure field: 39ms<br>
-Colony with jump-counting skipfield: 33ms</p>
+std::vector: 113ms<br>
+plf::colony (boolean skipfield): 39ms<br>
+plf::colony (jump-counting skipfield): 33ms</p>
 
 
 
-<h4>Duration to erase 49 out of every 50 consecutive elements, from container</h4>
-<p>(note: reverse-iteration was used for vector for the erasures - forward iteration and deletion took too long for the test to complete due to element reallocation. Both colony tests use forward iteration.)</p>
+<h5>Duration to erase 49 out of every 50 consecutive elements, from container</h5>
+<p><i>(note: reverse iteration was used for std::vector for the erasures in this test - forward iteration and erasure took too long for the test to complete due to subsequent element reallocation. Both plf::colony erasure tests use forward iteration.)</i></p>
 
-<p>Vector: 41359ms<br>
-Colony with boolean erasure field: 17ms<br>
-Colony with jump-counting skipfield: 20ms</p>
-
-
+std::vector: 41359ms<br>
+plf::colony (boolean skipfield): 17ms<br>
+plf::colony (jump-counting skipfield): 20ms</p>
 
 
-<h4>Duration to iterate over container data 10000 times and add value of integer member to total</h4>
 
-<p>Vector: 1002ms (1 second)<br>
-Colony with boolean field: 22355ms (22 seconds)<br>
-Colony with jump-counting skipfield: 1496ms (1.5 seconds)</p>
+<h5>Duration to iterate over container data 10000 times and add value of integer member to total</h5>
 
-<p><br>You can see from the iteration results that a skipfield using the advanced jump-counting pattern, while not achieving quite the same iteration performance as the vector (which reallocates data to achieve complete element contiguousness at the cost of pointer/iterator stability), also does not have the poor erasure performance associated with vector's data reallocation (mitigated in this case by using reverse iteration - in the general case forward iteration would be more common and the duration of vector's erasure result would be many factors-of-ten larger).</p>
+<p>std::vector: 1002ms (1 second)<br>
+plf::colony (boolean skipfield): 22355ms (22 seconds)<br>
+plf::colony (jump-counting skipfield): 1496ms (1.5 seconds)</p>
 
-<p>But more importantly it shows the dominance of the jump-counting skipfield pattern over a boolean erasure field implementation under worst-case testing, achieving approximately 15x the performance of the boolean erasure field. This is because in the scenario above the colony with the boolean erasure field has to do 49 value checks and if/then/else branches between every non-erased element, whereas in the jump-counting skipfield pattern implementation, there is only a single value check between non-erased elements and no branching.</p>
+<p><br>We can see from the results that a skipfield using the advanced jump-counting skipfield pattern, while not achieving the same iteration performance as std::vector (which reallocates data to achieve complete element contiguousness at the cost of pointer/iterator stability), also does not share the poor erasure performance associated with std::vector's data reallocation (mitigated in this case by using reverse iteration - in the general case forward iteration and the duration of erasure many factors-of-ten larger).</p>
 
-<p>As the ranges of consecutive erased elements increase, and as the ratio of erased elements to non-erased elements increases, so too does the performance advantage of the jump-counting skipfield over the boolean erasure field. For example, in the colony container, for a ratio of 65534 erased elements to every 1 non-erased element (the maximum ratio possible in colony architecture), a jump-counting skipfield implementation is approximately 6076x faster at iteration than using a boolean erasure field (results are dependent on the compiler and processor/OS).</p>
+<p>More importantly it shows the dominance of the jump-counting skipfield pattern over a boolean skipfield implementation under worst-case scenario testing, achieving approximately 1500% better performance. This is because in this scenario the plf::colony with the boolean skipfield has to do 49 value checks and if/else branches between each non-erased element, whereas with the jump-counting skipfield implementation there is only 1 value check between non-erased elements and no branching required.</p>
+
+<p>As numbers of consecutive erased elements increase, and as the ratio of erased elements to non-erased elements increases, so too does the iteration performance advantage of a jump-counting skipfield over a boolean skipfield. For the same test above but with a ratio of 65534 consecutive erased elements to every 1 non-erased element, a jump-counting skipfield implementation is approximately 607600% faster during iteration than it's boolean skipfield alternative (results vary dependent on the compiler and processor/OS).</p>
 
 
 <h2>Summary</h2>
-<p>In conclusion, given an appropriate application, using a jump-counting skipfield instead of a traditional boolean erasure field will reduce iteration times substantially and should be considered in the first instance of development where a boolean skipfield might typically be used. While the technique will work better in multiple-memory-block-based containers, where the block-size can be attenuated to allow for a smaller bitdepth in the skipfield nodes (for example, lowering maximum memory block size to 65535 elements enables the use of a 16-bit skipfield), it is still expected to have a strong performance impact in any scenarios where large amounts of consecutive 'inactive' container elements are expected. However in scenarios where element erasure is infrequent, a boolean field, using a lower-bit-depth, may have a better performance result. Additionally, in situations where iteration is infrequent, the overall performance benefit would be expected to be less. But for the vast majority of gaming applications, iteration over data is the most common per-frame activity, and hence, any increase in performance in that area will yield dividends.</p>
+<p>In conclusion, given an appropriate application, implementing a jump-counting skipfield instead of the traditional boolean skipfield will reduce iteration times when multiple consecutive erased elements are common, and should be considered in the first instance of development where a boolean skipfield might be used. While the pattern will work better in multiple-memory-block based containers, where the block-size can be attenuated to allow for a smaller bitdepth in the skipfield nodes (for example, lowering memory block size to 65535 elements enables the use of a 16-bit skipfield), it would still be expected to have a strong performance impact with larger memory fields requiring higher bitdepths, if multiple consecutive erased elements are common. In scenarios where element erasure is infrequent, a boolean field using a lower bit-depth may result in better performance. Additionally, in scenarios where iteration is infrequent, the overall performance benefit for the application would be expected to be less. However for scenarios where iteration over data is the most common activity, which includes vast majority of game applications, any increase in performance in the iteration domain will increase overall performance substantially, and a jump-counting skipfield may be worthwhile.</p>
+
+<p>The algorithm is principally serial and is unlikely to find significant application in massively-parallel architectures such as CUDA
 
 
 <p>Contact: <img src="footer.gif"><br>

--- a/Docs/plflib documentation - local cached copy - may become out of date/stack.htm
+++ b/Docs/plflib documentation - local cached copy - may become out of date/stack.htm
@@ -50,7 +50,7 @@ a #include command. The package includes both plf::colony and plf::stack.</p>
 
 <h2>Benchmarks</h2>
 
-<p style="font-size: 75%"><i>Last updated 22-02-2016 v3.00</i></p>
+<p style="font-size: 75%"><i>Last updated 24-03-2016 v3.02</i></p>
 
 <p>This benchmark compares performance between std::vector and plf::stack. I'm
 using std::vector instead of std::stack, as while std::stack usually uses
@@ -105,6 +105,14 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
       <td></td>
     </tr>
     <tr>
+      <td>std::stack</td>
+      <td>171</td>
+      <td>170</td>
+      <td>540</td>
+      <td>533</td>
+      <td></td>
+    </tr>
+    <tr>
       <td>plf::stack</td>
       <td>149</td>
       <td>117</td>
@@ -147,6 +155,14 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
       <td>39</td>
       <td>30</td>
       <td>43</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>std::stack</td>
+      <td>99</td>
+      <td>99</td>
+      <td>59</td>
+      <td>77</td>
       <td></td>
     </tr>
     <tr>
@@ -197,15 +213,23 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
       <td>std::vector</td>
       <td>311</td>
       <td>269</td>
-      <td>444</td>
+      <td>446</td>
       <td>465</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>std::stack</td>
+      <td>113</td>
+      <td>114</td>
+      <td>99</td>
+      <td>113</td>
       <td></td>
     </tr>
     <tr>
       <td>plf::stack</td>
       <td>96</td>
       <td>103</td>
-      <td>100</td>
+      <td>99</td>
       <td>104</td>
       <td></td>
     </tr>
@@ -244,6 +268,14 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
       <td>34</td>
       <td>34</td>
       <td>37</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>std::stack</td>
+      <td>104</td>
+      <td>87</td>
+      <td>33</td>
+      <td>36</td>
       <td></td>
     </tr>
     <tr>
@@ -296,6 +328,14 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
       <td></td>
     </tr>
     <tr>
+      <td>std::stack</td>
+      <td>142</td>
+      <td>154</td>
+      <td>416</td>
+      <td>351</td>
+      <td></td>
+    </tr>
+    <tr>
       <td>plf::stack</td>
       <td>138</td>
       <td>117</td>
@@ -338,6 +378,14 @@ with the small structs. Numbers are milliseconds, lower is better.</p>
       <td>9</td>
       <td>17</td>
       <td>29</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>std::stack</td>
+      <td>33</td>
+      <td>26</td>
+      <td>87</td>
+      <td>81</td>
       <td></td>
     </tr>
     <tr>

--- a/SG14/plf_stack.h
+++ b/SG14/plf_stack.h
@@ -4,73 +4,72 @@
 #define PLF_STACK_H
 
 
-// Compiler-specific defines used by both stack and colony:
-	
+// Compiler-specific defines used by stack:
+// Note: these macros are replicated between stack and colony but given different names, to avoid compiler issues with multiple inclusions of colony and stack with a project, caused by the #undef'ing of these macros at the end of the headers:
 #if defined(_MSC_VER)
 	#if _MSC_VER < 1600
-		#define PLF_NOEXCEPT throw()
+		#define PLF_STACK_NOEXCEPT throw()
 	#elif _MSC_VER == 1600
-		#define PLF_MOVE_SEMANTICS_SUPPORT
-		#define PLF_NOEXCEPT throw()
+		#define PLF_STACK_MOVE_SEMANTICS_SUPPORT
+		#define PLF_STACK_NOEXCEPT throw()
 	#elif _MSC_VER == 1700
-		#define PLF_TYPE_TRAITS_SUPPORT
-		#define PLF_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_MOVE_SEMANTICS_SUPPORT
-		#define PLF_NOEXCEPT throw()
+		#define PLF_STACK_TYPE_TRAITS_SUPPORT
+		#define PLF_STACK_ALLOCATOR_TRAITS_SUPPORT
+		#define PLF_STACK_MOVE_SEMANTICS_SUPPORT
+		#define PLF_STACK_NOEXCEPT throw()
 	#elif _MSC_VER == 1800
-		#define PLF_TYPE_TRAITS_SUPPORT
-		#define PLF_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_VARIADICS_SUPPORT
-		#define PLF_MOVE_SEMANTICS_SUPPORT
-		#define PLF_NOEXCEPT throw()
+		#define PLF_STACK_TYPE_TRAITS_SUPPORT
+		#define PLF_STACK_ALLOCATOR_TRAITS_SUPPORT
+		#define PLF_STACK_VARIADICS_SUPPORT
+		#define PLF_STACK_MOVE_SEMANTICS_SUPPORT
+		#define PLF_STACK_NOEXCEPT throw()
 	#elif _MSC_VER >= 1900
-		#define PLF_TYPE_TRAITS_SUPPORT
-		#define PLF_ALLOCATOR_TRAITS_SUPPORT
-		#define PLF_VARIADICS_SUPPORT
-		#define PLF_MOVE_SEMANTICS_SUPPORT
-		#define PLF_NOEXCEPT noexcept
+		#define PLF_STACK_TYPE_TRAITS_SUPPORT
+		#define PLF_STACK_ALLOCATOR_TRAITS_SUPPORT
+		#define PLF_STACK_VARIADICS_SUPPORT
+		#define PLF_STACK_MOVE_SEMANTICS_SUPPORT
+		#define PLF_STACK_NOEXCEPT noexcept
 	#endif
 #elif defined(__cplusplus) && __cplusplus >= 201103L
 	#if defined(__GNUC__) && !defined(__clang__) // If compiler is GCC/G++
 		#if __GNUC__ >= 5 // GCC v4.9 and below do not support std::is_trivially_copyable
-			#define PLF_TYPE_TRAITS_SUPPORT
+			#define PLF_STACK_TYPE_TRAITS_SUPPORT
 		#endif
 	#else // Assume type traits support for non-GCC compilers
-		#define PLF_TYPE_TRAITS_SUPPORT
+		#define PLF_STACK_TYPE_TRAITS_SUPPORT
 	#endif
 
-	#define PLF_ALLOCATOR_TRAITS_SUPPORT
-	#define PLF_VARIADICS_SUPPORT // Variadics, in this context, means both variadic templates and variadic macros are supported
-	#define PLF_MOVE_SEMANTICS_SUPPORT
-	#define PLF_NOEXCEPT noexcept
+	#define PLF_STACK_ALLOCATOR_TRAITS_SUPPORT
+	#define PLF_STACK_VARIADICS_SUPPORT // Variadics, in this context, means both variadic templates and variadic macros are supported
+	#define PLF_STACK_MOVE_SEMANTICS_SUPPORT
+	#define PLF_STACK_NOEXCEPT noexcept
 #else
-	#define PLF_NOEXCEPT throw()
+	#define PLF_STACK_NOEXCEPT throw()
 #endif
 
 
-
-#ifdef PLF_ALLOCATOR_TRAITS_SUPPORT
-	#ifdef PLF_VARIADICS_SUPPORT
-		#define PLF_CONSTRUCT(allocator_type, allocator_instance, location, ...) std::allocator_traits<allocator_type>::construct(allocator_instance, location, __VA_ARGS__)
+#ifdef PLF_STACK_ALLOCATOR_TRAITS_SUPPORT
+	#ifdef PLF_STACK_VARIADICS_SUPPORT
+		#define PLF_STACK_CONSTRUCT(allocator_type, allocator_instance, location, ...) std::allocator_traits<allocator_type>::construct(allocator_instance, location, __VA_ARGS__)
 	#else
-		#define PLF_CONSTRUCT(allocator_type, allocator_instance, location, data) std::allocator_traits<allocator_type>::construct(allocator_instance, location, data)
+		#define PLF_STACK_CONSTRUCT(allocator_type, allocator_instance, location, data) std::allocator_traits<allocator_type>::construct(allocator_instance, location, data)
 	#endif
 
-	#define PLF_DESTROY(allocator_type, allocator_instance, location) 			std::allocator_traits<allocator_type>::destroy(allocator_instance, location)
-	#define PLF_ALLOCATE(allocator_type, allocator_instance, size, hint) 		std::allocator_traits<allocator_type>::allocate(allocator_instance, size, hint)
- 	#define PLF_ALLOCATE_INITIALIZATION(allocator_type, size, hint) 			std::allocator_traits<allocator_type>::allocate(*this, size, hint)
-	#define PLF_DEALLOCATE(allocator_type, allocator_instance, location, size) 	std::allocator_traits<allocator_type>::deallocate(allocator_instance, location, size)
+	#define PLF_STACK_DESTROY(allocator_type, allocator_instance, location) 			std::allocator_traits<allocator_type>::destroy(allocator_instance, location)
+	#define PLF_STACK_ALLOCATE(allocator_type, allocator_instance, size, hint) 			std::allocator_traits<allocator_type>::allocate(allocator_instance, size, hint)
+ 	#define PLF_STACK_ALLOCATE_INITIALIZATION(allocator_type, size, hint) 				std::allocator_traits<allocator_type>::allocate(*this, size, hint)
+	#define PLF_STACK_DEALLOCATE(allocator_type, allocator_instance, location, size) 	std::allocator_traits<allocator_type>::deallocate(allocator_instance, location, size)
 #else
-	#ifdef PLF_VARIADICS_SUPPORT
-		#define PLF_CONSTRUCT(allocator_type, allocator_instance, location, ...) allocator_instance.construct(location, __VA_ARGS__)
+	#ifdef PLF_STACK_VARIADICS_SUPPORT
+		#define PLF_STACK_CONSTRUCT(allocator_type, allocator_instance, location, ...) allocator_instance.construct(location, __VA_ARGS__)
 	#else
-		#define PLF_CONSTRUCT(allocator_type, allocator_instance, location, data) allocator_instance.construct(location, data)
+		#define PLF_STACK_CONSTRUCT(allocator_type, allocator_instance, location, data) allocator_instance.construct(location, data)
 	#endif
 
-	#define PLF_DESTROY(allocator_type, allocator_instance, location) 			allocator_instance.destroy(location)
-	#define PLF_ALLOCATE(allocator_type, allocator_instance, size, hint) 		allocator_instance.allocate(size, hint)
-	#define PLF_ALLOCATE_INITIALIZATION(allocator_type, size, hint) 			allocator_type::allocate(size, hint)
-	#define PLF_DEALLOCATE(allocator_type, allocator_instance, location, size) 	allocator_instance.deallocate(location, size)
+	#define PLF_STACK_DESTROY(allocator_type, allocator_instance, location) 			allocator_instance.destroy(location)
+	#define PLF_STACK_ALLOCATE(allocator_type, allocator_instance, size, hint) 			allocator_instance.allocate(size, hint)
+	#define PLF_STACK_ALLOCATE_INITIALIZATION(allocator_type, size, hint) 				allocator_type::allocate(size, hint)
+	#define PLF_STACK_DEALLOCATE(allocator_type, allocator_instance, location, size) 	allocator_instance.deallocate(location, size)
 #endif
 
 
@@ -78,14 +77,14 @@
 
 
 #include <cassert>	// assert
-#include <limits>
+#include <limits>  // UINT_MAX
 #include <memory>	// std::uninitialized_copy, std::allocator
 
-#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+#ifdef PLF_STACK_MOVE_SEMANTICS_SUPPORT
 	#include <utility> // std::move
 #endif
 
-#ifdef PLF_TYPE_TRAITS_SUPPORT
+#ifdef PLF_STACK_TYPE_TRAITS_SUPPORT
     #include <type_traits> // std::is_trivially_destructible
 #endif
 
@@ -121,25 +120,25 @@ private:
 		const element_pointer_type	end; // End is the actual end element of the group, not one-past the end element as it is in colony
 
 
-		#ifdef PLF_VARIADICS_SUPPORT
-			group(const size_type elements_per_group, group_pointer_type const previous = NULL) PLF_NOEXCEPT:
-				elements(PLF_ALLOCATE_INITIALIZATION(element_allocator_type, elements_per_group, (previous == NULL) ? 0 : previous->elements)),
+		#ifdef PLF_STACK_VARIADICS_SUPPORT
+			group(const size_type elements_per_group, group_pointer_type const previous = NULL) PLF_STACK_NOEXCEPT:
+				elements(PLF_STACK_ALLOCATE_INITIALIZATION(element_allocator_type, elements_per_group, (previous == NULL) ? 0 : previous->elements)),
 				next_group(NULL),
 				previous_group(previous),
 				end(elements + elements_per_group - 1)
 			{}
 
 
-			~group() PLF_NOEXCEPT
+			~group() PLF_STACK_NOEXCEPT
 			{
-				PLF_DEALLOCATE(element_allocator_type, (*this), elements, (end - elements) + 1); // Size is calculated from end and elements pointers now
+				PLF_STACK_DEALLOCATE(element_allocator_type, (*this), elements, (end - elements) + 1); // Size is calculated from end and elements pointers now
 			}
 
 
 		#else
 			// This is a hack around the fact that element_allocator_type::construct only supports copy construction in C++0x and copy elision does not occur on the vast majority of compilers in this circumstance. And to avoid running out of memory (and performance loss) from allocating the same block twice, we're allocating in this constructor and moving data in the copy constructor:
 			group(const size_type elements_per_group, group_pointer_type const previous = NULL):
-				elements(PLF_ALLOCATE_INITIALIZATION(element_allocator_type, elements_per_group, (previous == NULL) ? 0 : previous->elements)),
+				elements(PLF_STACK_ALLOCATE_INITIALIZATION(element_allocator_type, elements_per_group, (previous == NULL) ? 0 : previous->elements)),
 				next_group(reinterpret_cast<group_pointer_type>(elements)), // for unique destructor condition
 				previous_group(previous),
 				end(elements + elements_per_group - 1)
@@ -147,7 +146,7 @@ private:
 
 
 			// Not a real copy constructor ie. actually a move constructor. Only used for allocator.construct in C++0x for reasons stated above.
-			group(const group &source) PLF_NOEXCEPT:
+			group(const group &source) PLF_STACK_NOEXCEPT:
 				elements(source.elements),
 				next_group(NULL),
 				previous_group(source.previous_group),
@@ -155,11 +154,11 @@ private:
 			{}
 
 
-			~group() PLF_NOEXCEPT
+			~group() PLF_STACK_NOEXCEPT
 			{
 				if (next_group != reinterpret_cast<group_pointer_type>(elements)) // Necessary to avoid deallocation for pseudoconstructor above
 				{
-					PLF_DEALLOCATE(element_allocator_type, (*this), elements, (end - elements) + 1);
+					PLF_STACK_DEALLOCATE(element_allocator_type, (*this), elements, (end - elements) + 1);
 				}
 			}
 		#endif
@@ -187,19 +186,19 @@ private:
 		assert(elements_per_group > 2);
 		assert(group_allocator_pair.max_elements_per_group <= std::numeric_limits<size_type>::max() / 2);
 
-		first_group = current_group = PLF_ALLOCATE(group_allocator_type, group_allocator_pair, 1, 0);
+		first_group = current_group = PLF_STACK_ALLOCATE(group_allocator_type, group_allocator_pair, 1, 0);
 
 		try
 		{
-			#ifdef PLF_VARIADICS_SUPPORT
-				PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, first_group, elements_per_group);
+			#ifdef PLF_STACK_VARIADICS_SUPPORT
+				PLF_STACK_CONSTRUCT(group_allocator_type, group_allocator_pair, first_group, elements_per_group);
 			#else
-				PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, first_group, group(elements_per_group));
+				PLF_STACK_CONSTRUCT(group_allocator_type, group_allocator_pair, first_group, group(elements_per_group));
 			#endif
 		}
 		catch (...)
 		{
-			PLF_DEALLOCATE(group_allocator_type, group_allocator_pair, first_group, 1);
+			PLF_STACK_DEALLOCATE(group_allocator_type, group_allocator_pair, first_group, 1);
 			throw;
 		}
 		
@@ -244,9 +243,9 @@ public:
 
 
 
-	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+	#ifdef PLF_STACK_MOVE_SEMANTICS_SUPPORT
 		// move constructor
-		stack(stack &&source) PLF_NOEXCEPT:
+		stack(stack &&source) PLF_STACK_NOEXCEPT:
 			current_group(std::move(source.current_group)),
 			first_group(std::move(source.first_group)),
 			current_element(std::move(source.current_element)),
@@ -269,20 +268,20 @@ public:
 	{
 		assert(&source != this);
 
-		first_group = current_group = PLF_ALLOCATE(group_allocator_type, group_allocator_pair, 1, 0);
+		first_group = current_group = PLF_STACK_ALLOCATE(group_allocator_type, group_allocator_pair, 1, 0);
 
 		// Initialize:
 		try
 		{
-			#ifdef PLF_VARIADICS_SUPPORT
-				PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, first_group, (total_number_of_elements < 3) ? 3 : total_number_of_elements);
+			#ifdef PLF_STACK_VARIADICS_SUPPORT
+				PLF_STACK_CONSTRUCT(group_allocator_type, group_allocator_pair, first_group, (total_number_of_elements < 3) ? 3 : total_number_of_elements);
 			#else
-				PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, first_group, group((total_number_of_elements < 3) ? 3 : total_number_of_elements));
+				PLF_STACK_CONSTRUCT(group_allocator_type, group_allocator_pair, first_group, group((total_number_of_elements < 3) ? 3 : total_number_of_elements));
 			#endif
 		}
 		catch (...)
 		{
-			PLF_DEALLOCATE(group_allocator_type, group_allocator_pair, first_group, 1);
+			PLF_STACK_DEALLOCATE(group_allocator_type, group_allocator_pair, first_group, 1);
 			throw;
 		}
 
@@ -305,7 +304,7 @@ public:
 
 
 
-	~stack() PLF_NOEXCEPT
+	~stack() PLF_STACK_NOEXCEPT
 	{
 		destroy_all_data();
 	}
@@ -314,9 +313,9 @@ public:
 
 private:
 
-	void destroy_all_data() PLF_NOEXCEPT
+	void destroy_all_data() PLF_STACK_NOEXCEPT
 	{
-		#ifdef PLF_TYPE_TRAITS_SUPPORT
+		#ifdef PLF_STACK_TYPE_TRAITS_SUPPORT
 			if (total_number_of_elements != 0 && !(std::is_trivially_destructible<element_type>::value)) // Avoid iteration for trivially-destructible types eg. POD, structs, classes with ermpty destructor
 		#else // If compiler doesn't support traits, iterate regardless - trivial destructors will not be called, hopefully compiler will optimise this loop out for POD types
 			if (total_number_of_elements != 0)
@@ -332,14 +331,14 @@ private:
 
 				for (element_pointer_type element_pointer = first_group->elements; element_pointer != past_end; ++element_pointer)
 				{
-					PLF_DESTROY(element_allocator_type, (*this), element_pointer);
+					PLF_STACK_DESTROY(element_allocator_type, (*this), element_pointer);
 				}
 
 				previous_group = first_group;
 				first_group = first_group->next_group;
 
-				PLF_DESTROY(group_allocator_type, group_allocator_pair, previous_group);
-				PLF_DEALLOCATE(group_allocator_type, group_allocator_pair, previous_group, 1);
+				PLF_STACK_DESTROY(group_allocator_type, group_allocator_pair, previous_group);
+				PLF_STACK_DEALLOCATE(group_allocator_type, group_allocator_pair, previous_group, 1);
 			}
 
 			// Special case for current group:
@@ -347,22 +346,22 @@ private:
 
 			for (element_pointer_type element_pointer = start_element; element_pointer != past_end; ++element_pointer)
 			{
-				PLF_DESTROY(element_allocator_type, (*this), element_pointer);
+				PLF_STACK_DESTROY(element_allocator_type, (*this), element_pointer);
 			}
 
-			PLF_DESTROY(group_allocator_type, group_allocator_pair, first_group);
-			PLF_DEALLOCATE(group_allocator_type, group_allocator_pair, first_group, 1);
+			PLF_STACK_DESTROY(group_allocator_type, group_allocator_pair, first_group);
+			PLF_STACK_DEALLOCATE(group_allocator_type, group_allocator_pair, first_group, 1);
 			first_group = NULL;
 		}
 		else
 		{
-			// Although technically under a type-traits-supporting compiler total_number_of_elements could be non-zero at this point, since first_group would already be NULL in the case of double-destruction, it's unnecessary to zero total_number_of_elements, and for some reason doing so creates a performance regression under gcc x64 (5.1 and below)
+			// Although technically under a type-traits-supporting compiler total_number_of_elements could be non-zero at this point, since first_group would already be NULL in the case of double-destruction, it's unnecessary to zero total_number_of_elements here
 			while (first_group != NULL)
 			{
 				current_group = first_group;
 				first_group = first_group->next_group;
-				PLF_DESTROY(group_allocator_type, group_allocator_pair, current_group);
-				PLF_DEALLOCATE(group_allocator_type, group_allocator_pair, current_group, 1);
+				PLF_STACK_DESTROY(group_allocator_type, group_allocator_pair, current_group);
+				PLF_STACK_DEALLOCATE(group_allocator_type, group_allocator_pair, current_group, 1);
 			}
 		}
 	}
@@ -377,7 +376,7 @@ public:
 		{
 			try
 			{
-				PLF_CONSTRUCT(element_allocator_type, (*this), ++current_element, the_element);
+				PLF_STACK_CONSTRUCT(element_allocator_type, (*this), ++current_element, the_element);
 			}
 			catch (...)
 			{
@@ -391,19 +390,19 @@ public:
 		{
 			if (current_group->next_group == NULL) 
 			{ 
-				current_group->next_group = PLF_ALLOCATE(group_allocator_type, group_allocator_pair, 1, current_group); 
+				current_group->next_group = PLF_STACK_ALLOCATE(group_allocator_type, group_allocator_pair, 1, current_group); 
 				
 				try
 				{ 
-					#ifdef PLF_VARIADICS_SUPPORT
-						PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, current_group->next_group, (total_number_of_elements < group_allocator_pair.max_elements_per_group) ? total_number_of_elements : group_allocator_pair.max_elements_per_group, current_group);
+					#ifdef PLF_STACK_VARIADICS_SUPPORT
+						PLF_STACK_CONSTRUCT(group_allocator_type, group_allocator_pair, current_group->next_group, (total_number_of_elements < group_allocator_pair.max_elements_per_group) ? total_number_of_elements : group_allocator_pair.max_elements_per_group, current_group);
 					#else
-						PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, current_group->next_group, group((total_number_of_elements < group_allocator_pair.max_elements_per_group) ? total_number_of_elements : group_allocator_pair.max_elements_per_group, current_group));
+						PLF_STACK_CONSTRUCT(group_allocator_type, group_allocator_pair, current_group->next_group, group((total_number_of_elements < group_allocator_pair.max_elements_per_group) ? total_number_of_elements : group_allocator_pair.max_elements_per_group, current_group));
 					#endif
 				} 
 				catch (...) 
 				{ 
-					PLF_DEALLOCATE(group_allocator_type, group_allocator_pair, current_group->next_group, 1);
+					PLF_STACK_DEALLOCATE(group_allocator_type, group_allocator_pair, current_group->next_group, 1);
 					current_group->next_group = NULL; 
 					throw; 
 				}
@@ -414,7 +413,7 @@ public:
 			
 			try
 			{
-				PLF_CONSTRUCT(element_allocator_type, (*this), current_element, the_element);
+				PLF_STACK_CONSTRUCT(element_allocator_type, (*this), current_element, the_element);
 			}
 			catch (...)
 			{
@@ -430,14 +429,14 @@ public:
 
 
 
-	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+	#ifdef PLF_STACK_MOVE_SEMANTICS_SUPPORT
 		void push(const element_type &&the_element)
 		{
 			if(current_element != current_group->end)
 			{
 				try
 				{
-					PLF_CONSTRUCT(element_allocator_type, (*this), ++current_element, std::move(the_element));
+					PLF_STACK_CONSTRUCT(element_allocator_type, (*this), ++current_element, std::move(the_element));
 				}
 				catch (...)
 				{
@@ -451,19 +450,19 @@ public:
 			{
 				if (current_group->next_group == NULL)
 				{
-					current_group->next_group = PLF_ALLOCATE(group_allocator_type, group_allocator_pair, 1, current_group);
+					current_group->next_group = PLF_STACK_ALLOCATE(group_allocator_type, group_allocator_pair, 1, current_group);
 	
                    	try
    					{
-   						#ifdef PLF_VARIADICS_SUPPORT
-   							PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, current_group->next_group, (total_number_of_elements < group_allocator_pair.max_elements_per_group) ? total_number_of_elements : group_allocator_pair.max_elements_per_group, current_group);
+   						#ifdef PLF_STACK_VARIADICS_SUPPORT
+   							PLF_STACK_CONSTRUCT(group_allocator_type, group_allocator_pair, current_group->next_group, (total_number_of_elements < group_allocator_pair.max_elements_per_group) ? total_number_of_elements : group_allocator_pair.max_elements_per_group, current_group);
    						#else
-   							PLF_CONSTRUCT(group_allocator_type, group_allocator_pair, current_group->next_group, group((total_number_of_elements < group_allocator_pair.max_elements_per_group) ? total_number_of_elements : group_allocator_pair.max_elements_per_group, current_group));
+   							PLF_STACK_CONSTRUCT(group_allocator_type, group_allocator_pair, current_group->next_group, group((total_number_of_elements < group_allocator_pair.max_elements_per_group) ? total_number_of_elements : group_allocator_pair.max_elements_per_group, current_group));
    						#endif
    					}
    					catch (...)
    					{
-   						PLF_DEALLOCATE(group_allocator_type, group_allocator_pair, current_group->next_group, 1);
+   						PLF_STACK_DEALLOCATE(group_allocator_type, group_allocator_pair, current_group->next_group, 1);
    						current_group->next_group = NULL;
    						throw;
    					}
@@ -474,7 +473,7 @@ public:
 	
 				try
 				{ 
-					PLF_CONSTRUCT(element_allocator_type, (*this), current_element, std::move(the_element));
+					PLF_STACK_CONSTRUCT(element_allocator_type, (*this), current_element, std::move(the_element));
 				}
 				catch (...)
 				{
@@ -489,7 +488,7 @@ public:
 		}
 
 
-		#ifdef PLF_VARIADICS_SUPPORT
+		#ifdef PLF_STACK_VARIADICS_SUPPORT
 			template<typename... Arguments> inline void emplace(Arguments... parameters)
 			{
 				push(element_type(std::forward<Arguments>(parameters)...)); // Use object's parameter'd constructor
@@ -499,7 +498,7 @@ public:
 
 
 
-	inline element_type & top() const PLF_NOEXCEPT
+	inline element_type & top() const PLF_STACK_NOEXCEPT
 	{
 		assert(!empty());
 		return *current_element;
@@ -507,15 +506,15 @@ public:
 
 
 
-	void pop() PLF_NOEXCEPT
+	void pop() PLF_STACK_NOEXCEPT
 	{
 		assert(!empty());
 
-		#ifdef PLF_TYPE_TRAITS_SUPPORT
+		#ifdef PLF_STACK_TYPE_TRAITS_SUPPORT
 			if (!(std::is_trivially_destructible<element_type>::value)) // This if-statement should be removed by the compiler on resolution of element_type
 		#endif
 		{
-			PLF_DESTROY(element_allocator_type, (*this), current_element);
+			PLF_STACK_DESTROY(element_allocator_type, (*this), current_element);
 		}
 		
 		
@@ -556,9 +555,9 @@ public:
 
 
 
-	#ifdef PLF_MOVE_SEMANTICS_SUPPORT
+	#ifdef PLF_STACK_MOVE_SEMANTICS_SUPPORT
 		// Move assignment
-		stack & operator = (stack &&source) PLF_NOEXCEPT
+		stack & operator = (stack &&source) PLF_STACK_NOEXCEPT
 		{
 			assert (&source != this);
 
@@ -581,14 +580,14 @@ public:
 
 
 
-	inline bool empty() const PLF_NOEXCEPT
+	inline bool empty() const PLF_STACK_NOEXCEPT
 	{
 		return total_number_of_elements == 0;
 	}
 
 
 	
-	inline size_type size() const PLF_NOEXCEPT
+	inline size_type size() const PLF_STACK_NOEXCEPT
 	{
 		return total_number_of_elements;
 	}
@@ -602,7 +601,7 @@ public:
 
 
 
-	bool operator == (const stack &rh) const PLF_NOEXCEPT
+	bool operator == (const stack &rh) const PLF_STACK_NOEXCEPT
 	{
 		assert (this != &rh);
 		
@@ -647,30 +646,29 @@ public:
 
 
 
-	inline bool operator != (const stack &rh) const PLF_NOEXCEPT
+	inline bool operator != (const stack &rh) const PLF_STACK_NOEXCEPT
 	{
 		return !(*this == rh);
 	}
 
 
-};
-
-}
+}; // stack
 
 
-#ifndef PLF_COLONY_H
-	#undef PLF_TYPE_TRAITS_SUPPORT
-	#undef PLF_ALLOCATOR_TRAITS_SUPPORT
-	#undef PLF_VARIADICS_SUPPORT
-	#undef PLF_MOVE_SEMANTICS_SUPPORT
-	#undef PLF_NOEXCEPT
+} // plf namespace
 
-	#undef PLF_CONSTRUCT
-	#undef PLF_DESTROY
-	#undef PLF_ALLOCATE
-	#undef PLF_ALLOCATE_INITIALIZATION
-	#undef PLF_DEALLOCATE
-#endif
+
+#undef PLF_STACK_TYPE_TRAITS_SUPPORT
+#undef PLF_STACK_ALLOCATOR_TRAITS_SUPPORT
+#undef PLF_STACK_VARIADICS_SUPPORT
+#undef PLF_STACK_MOVE_SEMANTICS_SUPPORT
+#undef PLF_STACK_NOEXCEPT
+
+#undef PLF_STACK_CONSTRUCT
+#undef PLF_STACK_DESTROY
+#undef PLF_STACK_ALLOCATE
+#undef PLF_STACK_ALLOCATE_INITIALIZATION
+#undef PLF_STACK_DEALLOCATE
 
 
 #endif // PLF_STACK_H

--- a/SG14_test/plf_benchmark.cpp
+++ b/SG14_test/plf_benchmark.cpp
@@ -20,27 +20,10 @@
 #include <iostream>
 #include <cstdlib> // rand
 #include <ctime> // timer
-#include <cstdio> // freopen
-//#include "SDL_timer.h" // Install and use SDL2 (libsdl.org) instead of ctime for more accurate cross-platform timing - regular STL/boost/C timing may only be accurate to around 15ms, regardless of function used (including high_resolution_clock), depending on the OS and compiler.
+#include <cstdio> // Redirect cout to log
 
 #include "plf_colony.h"
-
-
-inline unsigned long get_time_in_ms()
-{
-	return (unsigned long)((double(clock()) / CLOCKS_PER_SEC) * 1000);
-//	return (unsigned long) SDL_GetTicks(); // Use this for more accurate timing
-}
-
-
-void one_sec_delay()
-{
-	unsigned long end_time = get_time_in_ms() + 1000;
-
-	while(get_time_in_ms() < end_time)
-	{
-	}
-}
+#include "plf_nanotimer.h"
 
 
 
@@ -119,19 +102,18 @@ int main(int argc, char **argv)
 
 	cout << "Output results to (c)onsole or (l)ogfile? Type l or c and press Enter." << endl;
 	
-	char output_option;
+	char output_option = ' ';
 	bool console_output = true;
 	
-	cin.get(output_option);
-	
-	while (output_option != 'c' && output_option != 'C' && output_option != 'l' && output_option != 'L')
+	do 
 	{
 		cin.get(output_option);
-	}
-	
+	} while (output_option != 'c' && output_option != 'C' && output_option != 'l' && output_option != 'L');
+
 
 	cout << endl << endl << endl;
 	
+
 	if (output_option == 'l' || output_option == 'L')
 	{
 		char logfile[256];
@@ -143,6 +125,8 @@ int main(int argc, char **argv)
 		console_output = false;
 	}
 
+
+	nanotimer timer;
 
 
 	cout << "COLONY TESTS: REAL-WORLD SPEED\n===========================\n\n";
@@ -171,14 +155,14 @@ int main(int argc, char **argv)
 
 		cout << "small struct tests begin:" << endl << endl;
 		cout << "milliseconds to insert 2000000 generic structs:" << endl;
-		one_sec_delay(); // to remove potential overhead from cout.
+		millisecond_delay(1000); // to remove potential overhead from cout.
 
-		unsigned long current_time, difference1, difference2, difference3, difference4, difference5, difference6, difference7;
+		unsigned long difference1, difference2, difference3, difference4, difference5, difference6, difference7;
 		generic the_struct, *struct_pointer;
 		generic_for_array the_array_struct;
 		the_array_struct.erased = false;
 
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (unsigned int num = 0; num != 2000000; ++num)
 		{
@@ -187,8 +171,8 @@ int main(int argc, char **argv)
 			data_vector.push_back(struct_pointer);
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 2000000; ++num)
@@ -197,8 +181,8 @@ int main(int argc, char **argv)
 			data_colony.insert(the_struct);
 		}
 
-		difference2 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (unsigned int num = 0; num != 2000000; ++num)
 		{
@@ -207,8 +191,8 @@ int main(int argc, char **argv)
 			memcpy(&(data_array[num]), &the_array_struct, sizeof(generic_for_array));
 		}
 
-		difference3 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 2000000; ++num)
@@ -217,8 +201,8 @@ int main(int argc, char **argv)
 			data_list.push_front(the_struct);
 		}
 
-		difference4 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 2000000; ++num)
@@ -227,8 +211,8 @@ int main(int argc, char **argv)
 			data_map.insert(std::make_pair(num, the_struct));
 		}
 
-		difference5 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference5 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (unsigned int num = 0; num != 2000000; ++num)
 		{
@@ -237,8 +221,8 @@ int main(int argc, char **argv)
 			data_deque.push_back(struct_pointer);
 		}
 
-		difference6 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference6 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 2000000; ++num)
@@ -247,14 +231,14 @@ int main(int argc, char **argv)
 			data_multiset.insert(the_struct);
 		}
 
-		difference7 = get_time_in_ms() - current_time;
+		difference7 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "vector: " << difference1 << endl << "colony: " << difference2 << endl << "array: " << difference3 << endl  << "list: " << difference4 << endl  << "map: " << difference5 << endl << "deque: " << difference6 << endl << "multiset: " << difference7 << endl << endl;
 
 		cout << "milliseconds to randomly erase 1 in every 5000 entries:" << endl;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (vector<generic *>::iterator the_iterator = data_vector.begin(); the_iterator != data_vector.end();)
 		{
@@ -269,8 +253,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (colony<generic>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end();)
 		{
@@ -284,8 +268,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference2 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (unsigned int num = 0; num != 2000000; ++num)
 		{
@@ -295,8 +279,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference3 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (list<generic>::iterator the_iterator = data_list.begin(); the_iterator != data_list.end();)
 		{
@@ -310,8 +294,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference4 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (map<unsigned int, generic>::iterator the_iterator = data_map.begin(); the_iterator != data_map.end();)
 		{
@@ -328,25 +312,25 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference5 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference5 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
- 		for (deque<generic *>::iterator the_iterator = data_deque.begin(); the_iterator != data_deque.end();)
- 		{
- 			if (rand() % 5000 != 0)
- 			{
- 				++the_iterator;
- 			}
- 			else
- 			{
- 				delete *the_iterator;
- 				the_iterator = data_deque.erase(the_iterator);
- 			}
- 		}
+		for (deque<generic *>::iterator the_iterator = data_deque.begin(); the_iterator != data_deque.end();)
+		{
+			if (rand() % 5000 != 0)
+			{
+				++the_iterator;
+			}
+			else
+			{
+				delete *the_iterator;
+				the_iterator = data_deque.erase(the_iterator);
+			}
+		}
 
 
-		difference6 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference6 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (multiset<generic>::iterator the_iterator = data_multiset.begin(); the_iterator != data_multiset.end();)
 		{
@@ -362,15 +346,15 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference7 = get_time_in_ms() - current_time;
+		difference7 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "vector: " << difference1 << endl << "colony: " << difference2 << endl << "array: " << difference3 << endl  << "list: " << difference4 << endl  << "map: " << difference5 << endl << "deque: " << difference6 << endl << "multiset: " << difference7  << endl << endl;
 
 		double total;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -381,11 +365,11 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "totaling vector after random erasures: " << total << endl; // IMPORTANT NOTE - these cout's MUST be present or the compiler WILL (gcc does) optimize out ALL the loops containing 'total' because THEY DON'T DO ANYTHING (ie have any measurable side-effects) if total is not used for anything. Then your benchmarking becomes useless.
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -396,11 +380,11 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "totaling colony after random erasures: " << total << endl;
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -414,10 +398,10 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference3 = get_time_in_ms() - current_time;
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout <<  "totaling array after random erasures: " << total << endl;
-		one_sec_delay();
-		current_time = get_time_in_ms();
+		millisecond_delay(1000);
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -428,10 +412,10 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "totaling list after random erasures: " << total << endl;
-		one_sec_delay();
-		current_time = get_time_in_ms();
+		millisecond_delay(1000);
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -442,11 +426,11 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference5 = get_time_in_ms() - current_time;
+		difference5 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "totaling map after random erasures: " << total << endl;
 
-		one_sec_delay();
-		current_time = get_time_in_ms();
+		millisecond_delay(1000);
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -457,9 +441,9 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference6 = get_time_in_ms() - current_time;
+		difference6 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "totaling deque after random erasures: " << total << endl;
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -470,17 +454,17 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference7 = get_time_in_ms() - current_time;
+		difference7 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "totaling multiset after random erasures: " << total << endl << endl;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 		cout << "milliseconds to iterate over all entries 100 times and add stored random number to total:" << endl;
 		cout << "vector: " << difference1 << endl << "colony: " << difference2 << endl << "array: " << difference3 << endl  << "list: " << difference4 << endl  << "map: " << difference5 << endl << "deque: " << difference6 << endl << "multiset: " << difference7  << endl << endl;
 		cout << "milliseconds to clear containers and deallocate all objects:" << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (vector<generic *>::iterator the_iterator = data_vector.begin(); the_iterator != data_vector.end(); ++the_iterator)
 		{
@@ -488,24 +472,24 @@ int main(int argc, char **argv)
 		}
 
 		data_vector.clear();
-		difference1 = get_time_in_ms() - current_time;
-		one_sec_delay();
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		millisecond_delay(1000);
+		timer.start();
 		data_colony.clear();
-		difference2 = get_time_in_ms() - current_time;
-		one_sec_delay();
-		current_time = get_time_in_ms();
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		millisecond_delay(1000);
+		timer.start();
 		delete [] data_array;
-		difference3 = get_time_in_ms() - current_time;
-		one_sec_delay();
-		current_time = get_time_in_ms();
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		millisecond_delay(1000);
+		timer.start();
 		data_list.clear();
-		difference4 = get_time_in_ms() - current_time;
-		one_sec_delay();
-		current_time = get_time_in_ms();
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		millisecond_delay(1000);
+		timer.start();
 		data_map.clear();
-		difference5 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference5 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (deque<generic *>::iterator the_iterator = data_deque.begin(); the_iterator != data_deque.end(); ++the_iterator)
 		{
@@ -513,12 +497,12 @@ int main(int argc, char **argv)
 		}
 
 		data_deque.clear();
-		difference6 = get_time_in_ms() - current_time;
+		difference6 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
-		one_sec_delay();
-		current_time = get_time_in_ms();
+		millisecond_delay(1000);
+		timer.start();
 		data_multiset.clear();
-		difference7 = get_time_in_ms() - current_time;
+		difference7 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << endl << "vector: " << difference1 << endl << "colony: " << difference2 << endl << "array: " << difference3 << endl  << "list: " << difference4 << endl  << "map: " << difference5 << endl << "deque: " << difference6 << endl << "multiset: " << difference7  << endl << endl;
 		
@@ -554,13 +538,13 @@ int main(int argc, char **argv)
 		cout << "small struct tests begin:" << endl << endl;
 		cout << "milliseconds to insert 5000000 generic structs:" << endl;
 		
-		one_sec_delay(); // to remove potential overhead from cout.
+		millisecond_delay(1000); // to remove potential overhead from cout.
 
-		unsigned long current_time, difference1, difference2, difference3, difference4;
+		unsigned long difference1, difference2, difference3, difference4;
 		generic the_struct;
 		generic_for_array the_array_struct;
 		the_array_struct.erased = false;
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -568,8 +552,8 @@ int main(int argc, char **argv)
 			data_vector.push_back(the_array_struct);
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 5000000; ++num)
@@ -578,9 +562,9 @@ int main(int argc, char **argv)
 			data_colony.insert(the_struct);
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -589,9 +573,9 @@ int main(int argc, char **argv)
 			memcpy(&(data_array[num]), &the_array_struct, sizeof(generic_for_array));
 		}
 
-		difference3 = get_time_in_ms() - current_time;
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -599,16 +583,16 @@ int main(int argc, char **argv)
 			data_deque.push_back(the_array_struct);
 		}
 
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "vector: " << difference1 << endl << "colony: " << difference2 << endl << "array: " << difference3 << endl << "deque: " << difference4 << endl << endl;
 
 		cout << "milliseconds to randomly erase 1 in every 5000 entries:" << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (vector<generic_for_array>::iterator the_iterator = data_vector.begin(); the_iterator != data_vector.end(); ++the_iterator)
 		{
@@ -618,8 +602,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (colony<generic>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end();)
 		{
@@ -633,8 +617,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference2 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -644,8 +628,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference3 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (deque<generic_for_array>::iterator the_iterator = data_deque.begin(); the_iterator != data_deque.end(); ++the_iterator)
 		{
@@ -655,16 +639,16 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "vector: " << difference1 << endl << "colony: " << difference2 << endl << "array: " << difference3 << endl << "deque: " << difference4 << endl << endl;
 
 		
 
 		double total;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -678,12 +662,12 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "totaling vector after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -694,12 +678,12 @@ int main(int argc, char **argv)
 			}
 		}
 		
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "totaling colony after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -713,9 +697,9 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference3 = get_time_in_ms() - current_time;
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout <<  "totaling array after random erasures: " << total << endl << endl;
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -729,7 +713,7 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout <<  "totaling deque after random erasures: " << total << endl << endl;
 
 		cout << "milliseconds to iterate over all entries 100 times and add to total:" << endl;
@@ -768,11 +752,11 @@ int main(int argc, char **argv)
 		cout << "small struct tests begin:" << endl << endl;
 		cout << "milliseconds to insert 5000000 generic structs:" << endl;
 		
-		one_sec_delay(); // to remove potential overhead from cout.
+		millisecond_delay(1000); // to remove potential overhead from cout.
 
-		unsigned long current_time, difference1, difference2;
+		unsigned long difference1, difference2;
 		generic the_struct;
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -785,8 +769,8 @@ int main(int argc, char **argv)
 			pointer_vector.push_back(&(data_vector[num]));
 		}
 		
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 5000000; ++num)
@@ -795,16 +779,16 @@ int main(int argc, char **argv)
 			data_colony.insert(the_struct);
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "vector: " << difference1 << endl << "colony: " << difference2 << endl << endl;
 
 		cout << "milliseconds to randomly erase 1 in every 5000 entries:" << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (vector<generic *>::iterator the_iterator = pointer_vector.begin(); the_iterator != pointer_vector.end();)
 		{
@@ -818,8 +802,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (colony<generic>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end();)
 		{
@@ -833,16 +817,16 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "vector: " << difference1 << endl << "colony: " << difference2 << endl << endl;
 
 		
 
 		double total;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -853,12 +837,12 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "totaling vector after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -869,7 +853,7 @@ int main(int argc, char **argv)
 			}
 		}
 		
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "totaling colony after random erasures: " << total << endl;
 		
 		cout << "milliseconds to iterate over all entries 100 times and add to total:" << endl;
@@ -886,6 +870,147 @@ int main(int argc, char **argv)
 
 
 
+
+	// 4th real-world test - plf_colony speed against vector of indexs numbers of another vector, with a generic struct:
+	{
+		vector<generic> data_vector;
+		data_vector.reserve(65535);
+		vector<unsigned int> indexes_vector;
+		indexes_vector.reserve(65535);
+		colony<generic> data_colony(65535);
+
+
+		cout << "Real-world oo performance comparison between a std::vector of pointers to a vector of actual data, versus plf::colony, using small structs." << endl;
+
+		if (console_output)
+		{
+			cout << "Press enter to continue" << endl << endl;
+			cin.get();
+		}
+
+		cout << "small struct tests begin:" << endl << endl;
+		cout << "milliseconds to insert 5000000 generic structs:" << endl;
+		
+		millisecond_delay(1000); // to remove potential overhead from cout.
+
+		unsigned long difference1, difference2;
+		generic the_struct;
+		timer.start();
+
+		for (unsigned int num = 0; num != 5000000; ++num)
+		{
+			the_struct.number = rand() % 5000000;
+			data_vector.push_back(the_struct);
+		}
+
+		for (unsigned int num = 0; num != 5000000; ++num)
+		{
+			indexes_vector.push_back(num);
+		}
+		
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
+
+
+		for (unsigned int num = 0; num != 5000000; ++num)
+		{
+			the_struct.number = rand() % 5000000;
+			data_colony.insert(the_struct);
+		}
+
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+
+		cout << "vector: " << difference1 << endl << "colony: " << difference2 << endl << endl;
+
+		cout << "milliseconds to randomly erase 1 in every 5000 entries:" << endl;
+		
+		millisecond_delay(1000);
+
+
+		timer.start();
+
+		for (vector<unsigned int>::iterator the_iterator = indexes_vector.begin(); the_iterator != indexes_vector.end();)
+		{
+			if (rand() % 5000 != 0)
+			{
+				++the_iterator;
+			}
+			else
+			{
+				the_iterator = indexes_vector.erase(the_iterator);
+			}
+		}
+
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
+
+		for (colony<generic>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end();)
+		{
+			if (rand() % 5000 != 0)
+			{
+				++the_iterator;
+			}
+			else
+			{
+				the_iterator = data_colony.erase(the_iterator);
+			}
+		}
+
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		cout << "vector: " << difference1 << endl << "colony: " << difference2 << endl << endl;
+
+		
+
+		double total;
+		millisecond_delay(1000);
+
+
+		timer.start();
+		total = 0;
+
+		for (unsigned int counter = 0; counter != 100; ++counter)
+		{
+			for (vector<unsigned int>::iterator the_iterator = indexes_vector.begin(); the_iterator != indexes_vector.end(); ++the_iterator)
+			{
+				total += data_vector[*the_iterator].number;
+			}
+		}
+
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		cout << "totaling vector after random erasures: " << total << endl;
+		
+		millisecond_delay(1000);
+
+		timer.start();
+		total = 0;
+
+		for (unsigned int counter = 0; counter != 100; ++counter)
+		{
+			for (colony<generic>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)
+			{
+				total += the_iterator->number;
+			}
+		}
+		
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		cout << "totaling colony after random erasures: " << total << endl;
+		
+		cout << "milliseconds to iterate over all entries 100 times and add to total:" << endl;
+		cout << "vector: " << difference1 << endl << "colony: " << difference2 << endl << endl;
+
+		if (console_output)
+		{
+			cout << "Press enter to continue" << endl << endl;
+			cin.get();
+		}
+
+		cout << endl << endl << endl << endl << endl << endl << endl << endl;
+	}
+
+
+
+
+
 	cout << "COLONY TESTS: RAW SPEED\n=====================\n\n";
 
 
@@ -896,11 +1021,11 @@ int main(int argc, char **argv)
 		data_vector.reserve(65535);
 		colony<unsigned int> data_colony(65535);
 		
-        struct s_data 
-        {
-        	unsigned int number;
-        	bool erased;
-        };
+       struct s_data 
+       {
+       	unsigned int number;
+       	bool erased;
+       };
 
 		s_data *data_array = new s_data[5000000];
 
@@ -918,18 +1043,18 @@ int main(int argc, char **argv)
 		cout << "Unsigned int tests begin." << endl << endl;
 		cout << "Milliseconds to insert 50000000 unsigned ints:" << endl;
 		
-		one_sec_delay(); // To remove potential overhead from cout.
+		millisecond_delay(1000); // To remove potential overhead from cout.
 	
-		unsigned long current_time, difference1, difference2, difference3, difference4;
-		current_time = get_time_in_ms();
+		unsigned long difference1, difference2, difference3, difference4;
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
 			data_vector.push_back(rand() % 5000000);
 		}
 	
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 	
 	
 		for (unsigned int num = 0; num != 5000000; ++num)
@@ -937,8 +1062,8 @@ int main(int argc, char **argv)
 			data_colony.insert(rand() % 5000000);
 		}
 	
-		difference2 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 	
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -946,23 +1071,23 @@ int main(int argc, char **argv)
 			data_array[num].erased = false;
 		}
 
-		difference3 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
 			data_deque.push_back(rand() % 5000000);
 		}
 	
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << "Array: " << difference3 << endl << "Deque: " << difference4 << endl << endl;
 		cout << "Milliseconds to randomly erase 1 in every 5000 entries:" << endl;
 		 
-		one_sec_delay();
+		millisecond_delay(1000);
 
 	
-		current_time = get_time_in_ms();
+		timer.start();
 	
 		for (vector<unsigned int>::iterator the_iterator = data_vector.begin(); the_iterator != data_vector.end();)
 		{
@@ -976,8 +1101,8 @@ int main(int argc, char **argv)
 			}
 		}
 	
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 	
 		for (colony<unsigned int>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end();)
 		{
@@ -991,8 +1116,8 @@ int main(int argc, char **argv)
 			}
 		}
 	
-		difference2 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 	
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -1002,8 +1127,8 @@ int main(int argc, char **argv)
 			}
 		}
 	
-		difference3 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 	
 		for (deque<unsigned int>::iterator the_iterator = data_deque.begin(); the_iterator != data_deque.end();)
 		{
@@ -1017,15 +1142,15 @@ int main(int argc, char **argv)
 			}
 		}
 	
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << "Array: " << difference3 << endl << "Deque: " << difference4 << endl << endl;
 		
 		double total;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 	
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -1036,12 +1161,12 @@ int main(int argc, char **argv)
 			}
 		}
 	
-		difference1 = get_time_in_ms() - current_time;
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling vector after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 	
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -1052,12 +1177,12 @@ int main(int argc, char **argv)
 			}
 		}
 	
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling colony after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 	
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -1071,13 +1196,13 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference3 = get_time_in_ms() - current_time;
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout <<  "Totaling array after random erasures: " << total << endl << endl;
 
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 	
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -1088,7 +1213,7 @@ int main(int argc, char **argv)
 			}
 		}
 	
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling deque after random erasures: " << total << endl;
 		
 
@@ -1131,11 +1256,11 @@ int main(int argc, char **argv)
 		cout << "Small struct tests begin:" << endl << endl;
 		cout << "Milliseconds to insert 5000000 generic structs:" << endl;
 		
-		one_sec_delay(); // To remove potential overhead from cout.
+		millisecond_delay(1000); // To remove potential overhead from cout.
 
-		unsigned long current_time, difference1, difference2, difference3, difference4;
+		unsigned long difference1, difference2, difference3, difference4;
 		generic the_struct;
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -1143,8 +1268,8 @@ int main(int argc, char **argv)
 			data_vector.push_back(the_struct);
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 5000000; ++num)
@@ -1153,11 +1278,11 @@ int main(int argc, char **argv)
 			data_colony.insert(the_struct);
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		generic_for_array the_array_struct;
 		the_array_struct.erased = false;
 
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -1166,8 +1291,8 @@ int main(int argc, char **argv)
 			memcpy(&(data_array[num]), &the_array_struct, sizeof(generic_for_array));
 		}
 
-		difference3 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -1175,16 +1300,16 @@ int main(int argc, char **argv)
 			data_deque.push_back(the_struct);
 		}
 
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << "Array: " << difference3 << endl << "Deque: " << difference4 << endl << endl;
 
 		cout << "Milliseconds to randomly erase 1 in every 5000 entries:" << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 
 
 		for (vector<generic>::iterator the_iterator = data_vector.begin(); the_iterator != data_vector.end();)
@@ -1199,8 +1324,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (colony<generic>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end();)
 		{
@@ -1214,8 +1339,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference2 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
@@ -1225,8 +1350,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference3 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (deque<generic>::iterator the_iterator = data_deque.begin(); the_iterator != data_deque.end();)
 		{
@@ -1240,17 +1365,17 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << "Array: " << difference3 << endl << "Deque: " << difference4 << endl << endl;
 
 		
 
 		double total;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -1261,12 +1386,12 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling vector after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -1277,12 +1402,12 @@ int main(int argc, char **argv)
 			}
 		}
 		
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling colony after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -1296,11 +1421,11 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference3 = get_time_in_ms() - current_time;
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout <<  "Totaling array after random erasures: " << total << endl << endl;
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 100; ++counter)
@@ -1311,7 +1436,7 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling deque after random erasures: " << total << endl;
 
 
@@ -1352,12 +1477,12 @@ int main(int argc, char **argv)
 
 		cout << "Large struct tests begin:" << endl << endl;
 		cout << "Milliseconds to insert 10000 large structs:" << endl;
-  
-		one_sec_delay(); // To remove potential overhead from cout.
+ 
+		millisecond_delay(1000); // To remove potential overhead from cout.
 
-		unsigned long current_time, difference1, difference2, difference3, difference4;
+		unsigned long difference1, difference2, difference3, difference4;
 		large_generic the_struct;
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (unsigned int num = 0; num != 10000; ++num)
 		{
@@ -1365,8 +1490,8 @@ int main(int argc, char **argv)
 			data_vector.push_back(the_struct);
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 10000; ++num)
@@ -1375,10 +1500,10 @@ int main(int argc, char **argv)
 			data_colony.insert(the_struct);
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		large_generic_for_array the_array_struct;
 		the_array_struct.erased = false;
-		current_time = get_time_in_ms();
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 10000; ++num)
@@ -1387,8 +1512,8 @@ int main(int argc, char **argv)
 			memcpy(&data_array[num], &the_array_struct, sizeof(large_generic_for_array));
 		}
 
-		difference3 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (unsigned int num = 0; num != 10000; ++num)
 		{
@@ -1396,16 +1521,16 @@ int main(int argc, char **argv)
 			data_deque.push_back(the_struct);
 		}
 
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << "Array: " << difference3 << endl << "Deque: " << difference4 << endl << endl;
 
 		cout << "Milliseconds to randomly erase 1 in every 50 entries:" << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 
 
 		for (vector<large_generic>::iterator the_iterator = data_vector.begin(); the_iterator != data_vector.end();)
@@ -1420,8 +1545,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (colony<large_generic>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end();)
 		{
@@ -1435,8 +1560,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference2 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (unsigned int num = 0; num != 10000; ++num)
 		{
@@ -1446,8 +1571,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference3 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (deque<large_generic>::iterator the_iterator = data_deque.begin(); the_iterator != data_deque.end();)
 		{
@@ -1461,17 +1586,17 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << "Array: " << difference3 << endl << "Deque: " << difference4 << endl << endl;
 
 		
 
 		double total;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 10000; ++counter)
@@ -1482,12 +1607,12 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling vector after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 10000; ++counter)
@@ -1498,12 +1623,12 @@ int main(int argc, char **argv)
 			}
 		}
 		
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling colony after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 10000; ++counter)
@@ -1517,11 +1642,11 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference3 = get_time_in_ms() - current_time;
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout <<  "Totaling array after random erasures: " << total << endl << endl;
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 10000; ++counter)
@@ -1532,7 +1657,7 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference4 = get_time_in_ms() - current_time;
+		difference4 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling vector after random erasures: " << total << endl;
 		
 		cout << "Milliseconds to iterate over all entries 10000 times and add to total:" << endl;
@@ -1572,11 +1697,11 @@ int main(int argc, char **argv)
 		cout << "Small struct tests begin:" << endl << endl;
 		cout << "Milliseconds to insert 1000000 generic structs:" << endl;
 
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		unsigned long current_time, difference1, difference2;
+		unsigned long difference1, difference2;
 		generic the_struct;
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (unsigned int num = 0; num != 1000000; ++num)
 		{
@@ -1584,8 +1709,8 @@ int main(int argc, char **argv)
 			data_vector.push_back(the_struct);
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 1000000; ++num)
@@ -1594,16 +1719,16 @@ int main(int argc, char **argv)
 			data_colony.insert(the_struct);
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << endl;
 
 		cout << "Milliseconds to randomly erase 49 in every 50 entries:" << endl;
 
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		unsigned int counter = 0;
 
 		for (vector<generic>::reverse_iterator the_iterator = data_vector.rbegin(); the_iterator != data_vector.rend();)
@@ -1621,8 +1746,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 		counter = 0;
 
 		for (colony<generic>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end();)
@@ -1640,17 +1765,17 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << endl;
 
 		
 
 		double total;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 10000; ++counter)
@@ -1661,12 +1786,12 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling vector after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 10000; ++counter)
@@ -1677,7 +1802,7 @@ int main(int argc, char **argv)
 			}
 		}
 		
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling colony after random erasures: " << total << endl;
 		
 		cout << "Milliseconds to iterate over all entries 10000 times and add to total:" << endl;
@@ -1692,6 +1817,169 @@ int main(int argc, char **argv)
 		cout << endl << endl << endl << endl << endl << endl << endl << endl;
 	}
 
+
+	// Equal-case scenario for colony iteration, performance test using 100000 small structs:
+	{
+		vector<generic> data_vector;
+		data_vector.reserve(50);
+		colony<generic> data_colony(50);
+
+		cout << "Equal-case iteration performance comparison between std::vector, plf::colony" << endl;
+
+		if (console_output)
+		{
+			cout << "Press enter to continue" << endl << endl;
+			cin.get();
+		}
+
+
+		cout << "Small struct tests begin:" << endl << endl;
+		cout << "Milliseconds to insert 100000 generic structs:" << endl;
+
+		millisecond_delay(1000);
+
+		unsigned long difference1, difference2;
+		generic the_struct;
+		timer.start();
+
+		for (unsigned int num = 0; num != 100000; ++num)
+		{
+			the_struct.number = rand() % 100000;
+			data_vector.push_back(the_struct);
+		}
+
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
+
+
+		for (unsigned int num = 0; num != 100000; ++num)
+		{
+			the_struct.number = rand() % 100000;
+			data_colony.insert(the_struct);
+		}
+
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+
+		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << endl;
+
+		cout << "Milliseconds to randomly erase half of all entries:" << endl;
+
+		millisecond_delay(1000);
+
+
+		timer.start();
+		int counter = 0;
+
+		for (vector<generic>::reverse_iterator the_iterator = data_vector.rbegin(); the_iterator != data_vector.rend();)
+		{
+			
+			if (counter >= 0)
+			{
+				++counter;
+			
+				if (counter == 50)
+				{
+					counter = -1;
+					++the_iterator;
+				}
+				else
+				{
+					the_iterator = vector<generic>::reverse_iterator( data_vector.erase(--(the_iterator.base())));
+				}
+			}
+			else
+			{
+				if (--counter == -50)
+				{
+					counter = 0;
+				}
+
+				++the_iterator;
+			}
+		}
+
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
+		counter = 0;
+
+		for (colony<generic>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end();)
+		{
+			if (counter >= 0)
+			{
+				++counter;
+			
+				if (counter == 50)
+				{
+					counter = -1;
+					++the_iterator;
+				}
+				else
+				{
+					the_iterator = data_colony.erase(the_iterator);
+				}
+			}
+			else
+			{
+				if (--counter == -50)
+				{
+					counter = 0;
+				}
+
+				++the_iterator;
+			}
+		}
+
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+
+		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << endl;
+
+		
+
+		double total;
+		millisecond_delay(1000);
+
+
+		timer.start();
+		total = 0;
+
+		for (unsigned int counter = 0; counter != 10000; ++counter)
+		{
+			for (vector<generic>::iterator the_iterator = data_vector.begin(); the_iterator != data_vector.end(); ++the_iterator)
+			{
+				total += the_iterator->number;
+			}
+		}
+
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		cout << "Totaling vector after random erasures: " << total << endl;
+		
+		millisecond_delay(1000);
+
+		timer.start();
+		total = 0;
+
+		for (unsigned int counter = 0; counter != 10000; ++counter)
+		{
+			for (colony<generic>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end(); ++the_iterator)
+			{
+				total += the_iterator->number;
+			}
+		}
+		
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		cout << "Totaling colony after random erasures: " << total << endl;
+		
+		cout << "Milliseconds to iterate over all entries 10000 times and add to total:" << endl;
+		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << endl;
+
+		if (console_output)
+		{
+			cout << "Press enter to continue" << endl << endl;
+			cin.get();
+		}
+
+		cout << endl << endl << endl << endl << endl << endl << endl << endl;
+	}
 
 
 
@@ -1713,18 +2001,18 @@ int main(int argc, char **argv)
 		cout << "Small struct tests begin:" << endl << endl;
 		cout << "Milliseconds to insert 5000000 integers:" << endl;
 
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		unsigned long current_time, difference1, difference2;
-		current_time = get_time_in_ms();
+		unsigned long difference1, difference2;
+		timer.start();
 
 		for (unsigned int num = 0; num != 5000000; ++num)
 		{
 			data_vector.push_back(rand() % 1000000);
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 5000000; ++num)
@@ -1732,16 +2020,16 @@ int main(int argc, char **argv)
 			data_colony.insert(rand() % 1000000);
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << endl;
 
 		cout << "Milliseconds to randomly erase 65534 in every 65535 entries:" << endl;
 
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		unsigned int counter = 0;
 
 		for (vector<int>::reverse_iterator the_iterator = data_vector.rbegin(); the_iterator != data_vector.rend();)
@@ -1759,8 +2047,8 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 		counter = 0;
 
 		for (colony<int>::iterator the_iterator = data_colony.begin(); the_iterator != data_colony.end();)
@@ -1778,17 +2066,17 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << endl;
 
 		
 
 		double total;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 1000000; ++counter)
@@ -1799,12 +2087,12 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling vector after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 1000000; ++counter)
@@ -1815,7 +2103,7 @@ int main(int argc, char **argv)
 			}
 		}
 		
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling colony after random erasures: " << total << endl;
 		
 		cout << "Milliseconds to iterate over all entries 1000000 times and add to total:" << endl;
@@ -1851,11 +2139,11 @@ int main(int argc, char **argv)
 		cout << "Small struct tests begin:" << endl << endl;
 		cout << "Milliseconds to insert 1000000 generic structs:" << endl;
 		
-		one_sec_delay(); // To remove potential overhead from cout.
+		millisecond_delay(1000); // To remove potential overhead from cout.
 
-		unsigned long current_time, difference1, difference2;
+		unsigned long difference1, difference2;
 		generic the_struct;
-		current_time = get_time_in_ms();
+		timer.start();
 
 		for (unsigned int num = 0; num != 1000000; ++num)
 		{
@@ -1863,8 +2151,8 @@ int main(int argc, char **argv)
 			data_vector.push_back(the_struct);
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 1000000; ++num)
@@ -1873,16 +2161,16 @@ int main(int argc, char **argv)
 			data_colony.insert(the_struct);
 		}
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "Colony: " << difference2 << endl << endl;
 
 
 		double total;
-		one_sec_delay();
+		millisecond_delay(1000);
 
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 1000; ++counter)
@@ -1893,12 +2181,12 @@ int main(int argc, char **argv)
 			}
 		}
 
-		difference1 = get_time_in_ms() - current_time;
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling vector after random erasures: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 
 		for (unsigned int counter = 0; counter != 1000; ++counter)
@@ -1909,7 +2197,7 @@ int main(int argc, char **argv)
 			}
 		}
 		
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling colony after random erasures: " << total << endl;
 		
 		cout << "Milliseconds to iterate over all entries 1000 times and add to total:" << endl;
@@ -1954,18 +2242,18 @@ int main(int argc, char **argv)
 		cout << "Unsigned int tests begin:" << endl << endl;
 		cout << "Milliseconds to push 10000000 unsigned ints:" << endl;
 		
-		one_sec_delay(); // To remove potential overhead from cout.
+		millisecond_delay(1000); // To remove potential overhead from cout.
 
-		unsigned long current_time, difference1, difference2, difference3;
-		current_time = get_time_in_ms();
+		unsigned long difference1, difference2, difference3;
+		timer.start();
 
 		for (unsigned int num = 0; num != 10000000; ++num)
 		{
 			data_vector.push_back(rand() % 10000000);
 		}
 
-		difference1 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 
 		for (unsigned int num = 0; num != 10000000; ++num)
@@ -1973,22 +2261,22 @@ int main(int argc, char **argv)
 			data_stack.push(rand() % 10000000);
 		}
 	
-		difference2 = get_time_in_ms() - current_time;
-		current_time = get_time_in_ms();
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+		timer.start();
 
 		for (unsigned int num = 0; num != 10000000; ++num)
 		{
 			std_stack.push(rand() % 10000000);
 		}
 	
-		difference3 = get_time_in_ms() - current_time;
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 		cout << "Vector: " << difference1 << endl << "plf::stack: " << difference2 << endl << "std::stack: " << difference3 << endl << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 		double total;
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 	
 		for (unsigned int num = 0; num != 10000000; ++num)
@@ -1998,12 +2286,12 @@ int main(int argc, char **argv)
 		}
 
 
-		difference1 = get_time_in_ms() - current_time;
+		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 		cout << "Totaling vector: " << total << endl;
 		
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 	
 		for (unsigned int num = 0; num != 10000000; ++num)
@@ -2013,11 +2301,11 @@ int main(int argc, char **argv)
 		}
 
 
-		difference2 = get_time_in_ms() - current_time;
+		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
  		cout << "Totaling plf::stack: " << total << endl;
-		one_sec_delay();
+		millisecond_delay(1000);
 
-		current_time = get_time_in_ms();
+		timer.start();
 		total = 0;
 	
 		for (unsigned int num = 0; num != 10000000; ++num)
@@ -2027,7 +2315,7 @@ int main(int argc, char **argv)
 		}
 
 
-		difference3 = get_time_in_ms() - current_time;
+		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 
 
@@ -2068,10 +2356,10 @@ int main(int argc, char **argv)
  		cout << "Small struct tests begin:" << endl << endl;
  		cout << "Milliseconds to push 5000000 generic structs:" << endl;
  		
- 		one_sec_delay(); // To remove potential overhead from cout.
+ 		millisecond_delay(1000); // To remove potential overhead from cout.
  
- 		unsigned long current_time, difference1, difference2, difference3;
- 		current_time = get_time_in_ms();
+ 		unsigned long difference1, difference2, difference3;
+ 		timer.start();
  		generic the_struct;
  
  		for (unsigned int num = 0; num != 5000000; ++num)
@@ -2080,8 +2368,8 @@ int main(int argc, char **argv)
  			data_vector.push_back(the_struct);
  		}
  	
- 		difference1 = get_time_in_ms() - current_time;
- 		current_time = get_time_in_ms();
+ 		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+ 		timer.start();
  
  	
  		for (unsigned int num = 0; num != 5000000; ++num)
@@ -2090,9 +2378,9 @@ int main(int argc, char **argv)
  			data_stack.push(the_struct);
  		}
  	
- 		difference2 = get_time_in_ms() - current_time;
+ 		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
  
- 		current_time = get_time_in_ms();
+ 		timer.start();
  
  	
  		for (unsigned int num = 0; num != 5000000; ++num)
@@ -2101,14 +2389,14 @@ int main(int argc, char **argv)
  			std_stack.push(the_struct);
  		}
  	
- 		difference3 = get_time_in_ms() - current_time;
+ 		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
  
 		cout << "Vector: " << difference1 << endl << "plf::stack: " << difference2 << endl << "std::stack: " << difference3 << endl << endl;
  		
- 		one_sec_delay();
+ 		millisecond_delay(1000);
  		double total;
  
- 		current_time = get_time_in_ms();
+ 		timer.start();
  		total = 0;
  	
  		for (unsigned int num = 0; num != 5000000; ++num)
@@ -2119,12 +2407,12 @@ int main(int argc, char **argv)
  		}
  
  
- 		difference1 = get_time_in_ms() - current_time;
+ 		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
  		cout << "Totaling vector: " << total << endl;
  		
- 		one_sec_delay();
+ 		millisecond_delay(1000);
  
- 		current_time = get_time_in_ms();
+ 		timer.start();
  		total = 0;
  	
  		for (unsigned int num = 0; num != 5000000; ++num)
@@ -2135,11 +2423,11 @@ int main(int argc, char **argv)
  		}
  
  	
- 		difference2 = get_time_in_ms() - current_time;
+ 		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
  		cout << "Totaling plf::stack: " << total << endl;
- 		one_sec_delay();
+ 		millisecond_delay(1000);
  
- 		current_time = get_time_in_ms();
+ 		timer.start();
  		total = 0;
  	
  		for (unsigned int num = 0; num != 5000000; ++num)
@@ -2150,7 +2438,7 @@ int main(int argc, char **argv)
  		}
  
  	
- 		difference3 = get_time_in_ms() - current_time;
+ 		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 
  		cout << "Totaling std::stack: " << total << endl << endl;
@@ -2189,10 +2477,10 @@ int main(int argc, char **argv)
  		cout << "Large struct tests begin:" << endl << endl;
  		cout << "Milliseconds to push 10000 large generic structs:" << endl;
  		
- 		one_sec_delay(); // To remove potential overhead from cout.
+ 		millisecond_delay(1000); // To remove potential overhead from cout.
  
- 		unsigned long current_time, difference1, difference2, difference3;
- 		current_time = get_time_in_ms();
+ 		unsigned long difference1, difference2, difference3;
+ 		timer.start();
  		large_generic the_struct;
  
  		for (unsigned int num = 0; num != 10000; ++num)
@@ -2201,8 +2489,8 @@ int main(int argc, char **argv)
  			data_vector.push_back(the_struct);
  		}
  	
- 		difference1 = get_time_in_ms() - current_time;
- 		current_time = get_time_in_ms();
+ 		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
+ 		timer.start();
  
  	
  		for (unsigned int num = 0; num != 10000; ++num)
@@ -2211,9 +2499,9 @@ int main(int argc, char **argv)
  			data_stack.push(the_struct);
  		}
  	
- 		difference2 = get_time_in_ms() - current_time;
+ 		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
  
- 		current_time = get_time_in_ms();
+ 		timer.start();
  
  	
  		for (unsigned int num = 0; num != 10000; ++num)
@@ -2222,14 +2510,14 @@ int main(int argc, char **argv)
  			std_stack.push(the_struct);
  		}
  	
- 		difference3 = get_time_in_ms() - current_time;
+ 		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
  
 		cout << "Vector: " << difference1 << endl << "plf::stack: " << difference2 << endl << "std::stack: " << difference3 << endl << endl;
  		
- 		one_sec_delay();
+ 		millisecond_delay(1000);
  		double total;
 
- 		current_time = get_time_in_ms();
+ 		timer.start();
  		total = 0;
  	
  		for (unsigned int num = 0; num != 10000; ++num)
@@ -2240,12 +2528,12 @@ int main(int argc, char **argv)
  		}
  
  
- 		difference1 = get_time_in_ms() - current_time;
+ 		difference1 = static_cast<unsigned long int>(timer.get_elapsed_ms());
  		cout << "Totaling vector: " << total << endl;
    
- 		one_sec_delay();
+ 		millisecond_delay(1000);
  
- 		current_time = get_time_in_ms();
+ 		timer.start();
  		total = 0;
  	
  		for (unsigned int num = 0; num != 10000; ++num)
@@ -2256,11 +2544,11 @@ int main(int argc, char **argv)
  		}
 
  	
- 		difference2 = get_time_in_ms() - current_time;
+ 		difference2 = static_cast<unsigned long int>(timer.get_elapsed_ms());
  		cout << "Totaling plf::stack: " << total << endl;
- 		one_sec_delay();
+ 		millisecond_delay(1000);
  
- 		current_time = get_time_in_ms();
+ 		timer.start();
  		total = 0;
  	
  		for (unsigned int num = 0; num != 10000; ++num)
@@ -2271,7 +2559,7 @@ int main(int argc, char **argv)
  		}
  
 	
- 		difference3 = get_time_in_ms() - current_time;
+ 		difference3 = static_cast<unsigned long int>(timer.get_elapsed_ms());
 
 
  		cout << "Totaling std::stack: " << total << endl << endl;

--- a/SG14_test/plf_nanotimer.h
+++ b/SG14_test/plf_nanotimer.h
@@ -1,0 +1,163 @@
+#ifndef PLF_NANOTIMER
+#define PLF_NANOTIMER
+
+
+// ~Nanosecond-precision cross-platform (linux/bsd/mac/windows, C++03/C++11) simple timer class:
+
+namespace plf
+{
+
+// Mac OSX implementation:
+#ifdef __MACH__
+	#include <mach/clock.h>
+	#include <mach/mach.h>
+	
+	class nanotimer
+	{
+	private:
+		clock_serv_t system_clock;
+		mach_timespec_t time1, time2;
+	public:
+		nanotimer()
+		{
+			host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &system_clock);
+		}
+		
+		~nanotimer()
+		{
+			mach_port_deallocate(mach_task_self(), system_clock);
+		}
+		
+		inline void start()
+		{
+			clock_get_time(system_clock, &time1);
+		}
+		
+		inline double get_elapsed_ms()
+		{
+			return static_cast<double>(get_elasped_ns()) / 1000000.0;
+		}
+
+		inline double get_elapsed_us()
+		{
+			return static_cast<double>(get_elasped_ns()) / 1000.0;
+		}
+
+		double get_elasped_ns()
+		{
+			clock_get_time(system_clock, &time2);
+			return ((1000000000.0 * static_cast<double>(time2.tv_sec - time1.tv_sec)) + static_cast<double>(time2.tv_nsec - time1.tv_nsec));
+		}
+	};
+#endif
+
+
+
+
+// Linux/BSD implementation:
+#if (defined(linux) || defined(__linux__) || defined(__linux)) || (defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__))
+	#include <time.h>
+	#include <sys/time.h>	
+
+	class nanotimer
+	{
+	private:
+		struct timespec time1, time2;
+	public:
+		nanotimer() {}
+		
+		inline void start()
+		{
+			clock_gettime(CLOCK_MONOTONIC, &time1);
+		}
+		
+		inline double get_elapsed_ms()
+		{
+			return get_elapsed_ns() / 1000000.0;
+		}
+
+		inline double get_elapsed_ms()
+		{
+			return get_elapsed_ns() / 1000.0;
+		}
+
+		double get_elapsed_ns()
+		{
+			clock_gettime(CLOCK_MONOTONIC, &time2);
+			return ((1000000000.0 * static_cast<double>(time2.tv_sec - time1.tv_sec)) + static_cast<double>(time2.tv_nsec - time1.tv_nsec));
+		}
+	};
+#endif
+
+
+
+
+// Windows implementation:
+#ifdef _WIN32
+	#include <windows.h>
+	
+	class nanotimer
+	{
+	private:
+		LARGE_INTEGER ticks1, ticks2;
+		double frequency;
+	public:
+		nanotimer()
+		{
+			LARGE_INTEGER freq;
+			QueryPerformanceFrequency(&freq);
+			frequency = static_cast<double>(freq.QuadPart);
+		}
+		
+		inline void start()
+		{
+			QueryPerformanceCounter(&ticks1);
+		}
+		
+		double get_elapsed_ms()
+		{
+			QueryPerformanceCounter(&ticks2);
+			return (static_cast<double>(ticks2.QuadPart - ticks1.QuadPart) * 1000.0) / frequency;
+		}
+
+		inline double get_elapsed_us()
+		{
+			return get_elapsed_ms() * 1000.0;
+		}
+
+		inline double get_elapsed_ns()
+		{
+			return get_elapsed_ms() * 1000000.0;
+		}
+	};
+#endif
+
+
+
+
+inline void nanosecond_delay(double delay_ns)
+{
+	nanotimer timer;
+	timer.start();
+	
+	while(timer.get_elapsed_ns() < delay_ns)
+	{};
+}
+
+
+
+inline void microsecond_delay(double delay_us)
+{
+	nanosecond_delay(delay_us * 1000.0);
+}
+
+
+inline void millisecond_delay(double delay_ms) 
+{
+	nanosecond_delay(delay_ms * 1000000.0);
+}
+
+
+} // namespace
+
+#endif // PLF_NANOTIMER

--- a/SG14_test/plf_test_suite.cpp
+++ b/SG14_test/plf_test_suite.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <algorithm>
+#include <cstdio> // log redirection
 #include <cstdlib> // rand
 #include <ctime> // timer
 #include "plf_colony.h"
@@ -22,7 +23,6 @@ void failpass(const char *test_type, bool condition)
 	std::cout << test_type << ": ";
 	
 	if (condition) 
-	
 	{ 
 		std::cout << "Pass" << std::endl;
 	} 
@@ -40,7 +40,13 @@ namespace sg14_test
 
 void plf_test_suite()
 {
-	srand(clock()); // Note: using random numbers to avoid CPU predictive
+	freopen("error.log","w", stderr);
+
+	{
+		time_t timer;
+		time(&timer);
+		srand((unsigned int)timer); // Note: using random numbers to avoid CPU prediction
+	}
 
 	using namespace std;
 	using namespace plf;
@@ -141,8 +147,6 @@ void plf_test_suite()
 
 		colony<int *>::reverse_iterator r_iterator2 = p_colony.next(r_iterator, 2);
 
-		cout << p_colony.distance(p_colony.rbegin(), r_iterator2) << endl;
-		
 		failpass("Reverse iterator next and distance test", p_colony.distance(p_colony.rbegin(), r_iterator2) == -52);
 		
 		numtotal = 0;
@@ -291,6 +295,37 @@ void plf_test_suite()
 		}
 		
 		failpass("Size after reinitialize + insert test", i_colony.size() == 30000);
+
+		unsigned short count2 = 0;
+		
+		do
+		{
+			for (colony<int>::iterator the_iterator = i_colony.begin(); the_iterator != i_colony.end();)
+			{
+				if (rand() % 5 == 0)
+				{
+					the_iterator = i_colony.erase(the_iterator);
+					++count2;
+				}
+				else
+				{
+					colony<int>::iterator temp_iterator = the_iterator;
+					++the_iterator;
+				}
+			}
+			
+		} while (count2 < 15000);
+		
+		failpass("Erase randomly till half-empty test", i_colony.size() == 30000u - count2);
+
+		for (unsigned int temp = 0; temp != count2; ++temp)
+		{
+			i_colony.insert(1);
+		}
+		
+		failpass("Size after reinsert test", i_colony.size() == 30000);
+
+
 
 
 		unsigned int sum = 0;
@@ -448,7 +483,6 @@ void plf_test_suite()
 		}
 		
 		failpass("Multiple sequential small insert/erase commands test", count == i_colony.size());
-		
 	}
 
 
@@ -513,6 +547,6 @@ void plf_test_suite()
 
 	title1("Test Suite PASS - Press ENTER to Exit");
 	cin.get();
+}
 
-	return 0;
 }


### PR DESCRIPTION
 v3.03 - Correction to operator = on colony. Replaced SDL2/SDL_Timer in benchmarks with plf_nanotimer, a cross-platform simplified ~nanosecond-precision timer, as std::chrono doesn't typically give sub-timeslice results on windows compilers. Correction to end() and begin() overloads - internal begin/end iterator could previously be altered by user activity, in some cases. Correction to .next functions. Small performance improvements. Duplication of macros from plf_stack.h to plf_colony.h to fix issue when plf_stack.h is also used within project separately from plf_colony.h. 
Updated benchmarks in docs. Added nanotimer to docs.
Current benchmarks innaccurate, to be replaced in future.