### PR TITLE
Adding friend clause for other inplace_function

### DIFF
--- a/SG14/inplace_function.h
+++ b/SG14/inplace_function.h
@@ -14,6 +14,9 @@ template <typename RetT, typename... ArgsT, size_t CapacityT, size_t AlignmentT>
 class inplace_function<RetT(ArgsT...), CapacityT, AlignmentT>
 {
 public:
+	template <typename SignatureT, std::size_t CapacityT, std::size_t AlignmentT>
+	friend class inplace_function;
+	
 	// TODO static_assert for misalignment
 	// TODO create free operator overloads, to handle switched arguments
 


### PR DESCRIPTION
Fix when assigning to bigger size inplace_function.  Was before complaining about accessing private member.  Adding friend clause.