### PR TITLE
Fix various ring_iterator snafus and a bug in push_back.

### DIFF
--- a/SG14/ring.h
+++ b/SG14/ring.h
@@ -132,7 +132,6 @@ namespace sg14
 		friend Ring;
 		using size_type = typename Ring::size_type;
 		ring_iterator(size_type idx, std::conditional_t<is_const, const Ring, Ring>* rv) noexcept;
-		size_type modulo_capacity(size_type idx) const noexcept;
 		size_type m_idx;
 		std::conditional_t<is_const, const Ring, Ring>* m_rv;
 	};
@@ -344,7 +343,7 @@ template <typename Ring, bool is_const>
 template<bool C>
 bool sg14::ring_iterator<Ring, is_const>::operator==(const sg14::ring_iterator<Ring, C>& rhs) const noexcept
 {
-	return (modulo_capacity(m_idx) == rhs.modulo_capacity(m_idx)) && (m_rv == rhs.m_rv);
+	return (m_idx == rhs.m_idx) && (m_rv == rhs.m_rv);
 }
 
 template <typename Ring, bool is_const>
@@ -358,28 +357,28 @@ template <typename Ring, bool is_const>
 template<bool C>
 bool sg14::ring_iterator<Ring, is_const>::operator<(const sg14::ring_iterator<Ring, C>& rhs) const noexcept
 {
-	return (modulo_capacity(m_idx) < rhs.modulo_capacity(m_idx)) && (m_rv == rhs.m_rv);
+	return (m_idx < rhs.m_idx) && (m_rv == rhs.m_rv);
 }
 
 template <typename Ring, bool is_const>
 template<bool C>
 bool sg14::ring_iterator<Ring, is_const>::operator<=(const sg14::ring_iterator<Ring, C>& rhs) const noexcept
 {
-	return (modulo_capacity(m_idx) <= rhs.modulo_capacity(m_idx)) && (m_rv == rhs.m_rv);
+	return (m_idx <= rhs.m_idx) && (m_rv == rhs.m_rv);
 }
 
 template <typename Ring, bool is_const>
 template<bool C>
 bool sg14::ring_iterator<Ring, is_const>::operator>(const sg14::ring_iterator<Ring, C>& rhs) const noexcept
 {
-	return (modulo_capacity(m_idx) > rhs.modulo_capacity(m_idx)) && (m_rv == rhs.m_rv);
+	return (m_idx > rhs.m_idx) && (m_rv == rhs.m_rv);
 }
 
 template <typename Ring, bool is_const>
 template<bool C>
 bool sg14::ring_iterator<Ring, is_const>::operator>=(const sg14::ring_iterator<Ring, C>& rhs) const noexcept
 {
-	return (modulo_capacity(m_idx) > rhs.modulo_capacity(m_idx)) && (m_rv == rhs.m_rv);
+	return (m_idx > rhs.m_idx) && (m_rv == rhs.m_rv);
 }
 
 template <typename Ring, bool is_const>
@@ -437,12 +436,6 @@ sg14::ring_iterator<Ring, is_const>::ring_iterator(typename sg14::ring_iterator<
 	: m_idx(idx)
 	, m_rv(rv)
 {}
-
-template <typename Ring, bool is_const>
-typename sg14::ring_iterator<Ring, is_const>::size_type sg14::ring_iterator<Ring, is_const>::modulo_capacity(size_type idx) const noexcept
-{
-	return idx % m_rv->capacity();
-}
 
 template <typename Ring, bool is_const>
 sg14::ring_iterator<Ring, is_const> operator+(sg14::ring_iterator<Ring, is_const> it, int i) noexcept

--- a/SG14/ring.h
+++ b/SG14/ring.h
@@ -131,10 +131,10 @@ namespace sg14
 	private:
 		friend Ring;
 		using size_type = typename Ring::size_type;
-		ring_iterator(size_type idx, Ring* rv) noexcept;
+		ring_iterator(size_type idx, std::conditional_t<is_const, const Ring, Ring>* rv) noexcept;
 		size_type modulo_capacity(size_type idx) const noexcept;
 		size_type m_idx;
-		Ring* m_rv;
+		std::conditional_t<is_const, const Ring, Ring>* m_rv;
 	};
 }
 
@@ -433,7 +433,7 @@ sg14::ring_iterator<Ring, is_const>& operator-=(sg14::ring_iterator<Ring, is_con
 }
 
 template <typename Ring, bool is_const>
-sg14::ring_iterator<Ring, is_const>::ring_iterator(typename sg14::ring_iterator<Ring, is_const>::size_type idx, Ring* rv) noexcept
+sg14::ring_iterator<Ring, is_const>::ring_iterator(typename sg14::ring_iterator<Ring, is_const>::size_type idx, std::conditional_t<is_const, const Ring, Ring>* rv) noexcept
 	: m_idx(idx)
 	, m_rv(rv)
 {}

--- a/SG14/ring.h
+++ b/SG14/ring.h
@@ -108,7 +108,15 @@ namespace sg14
 		template <bool C>
 		bool operator==(const ring_iterator<Ring, C>& rhs) const noexcept;
 		template <bool C>
+		bool operator!=(const ring_iterator<Ring, C>& rhs) const noexcept;
+		template <bool C>
 		bool operator<(const ring_iterator<Ring, C>& rhs) const noexcept;
+		template <bool C>
+		bool operator<=(const ring_iterator<Ring, C>& rhs) const noexcept;
+		template <bool C>
+		bool operator>(const ring_iterator<Ring, C>& rhs) const noexcept;
+		template <bool C>
+		bool operator>=(const ring_iterator<Ring, C>& rhs) const noexcept;
 
 		reference operator*() const noexcept;
 		type& operator++() noexcept;
@@ -124,7 +132,7 @@ namespace sg14
 		friend Ring;
 		using size_type = typename Ring::size_type;
 		ring_iterator(size_type idx, Ring* rv) noexcept;
-		size_type modulo_capacity(size_type idx) noexcept;
+		size_type modulo_capacity(size_type idx) const noexcept;
 		size_type m_idx;
 		Ring* m_rv;
 	};
@@ -340,9 +348,37 @@ bool sg14::ring_iterator<Ring, is_const>::operator==(const sg14::ring_iterator<R
 
 template <typename Ring, bool is_const>
 template<bool C>
+bool sg14::ring_iterator<Ring, is_const>::operator!=(const sg14::ring_iterator<Ring, C>& rhs) const noexcept
+{
+	return !(*this == rhs);
+}
+
+template <typename Ring, bool is_const>
+template<bool C>
 bool sg14::ring_iterator<Ring, is_const>::operator<(const sg14::ring_iterator<Ring, C>& rhs) const noexcept
 {
 	return (modulo_capacity(m_idx) < rhs.modulo_capacity(m_idx)) && (m_rv == rhs.m_rv);
+}
+
+template <typename Ring, bool is_const>
+template<bool C>
+bool sg14::ring_iterator<Ring, is_const>::operator<=(const sg14::ring_iterator<Ring, C>& rhs) const noexcept
+{
+	return (modulo_capacity(m_idx) <= rhs.modulo_capacity(m_idx)) && (m_rv == rhs.m_rv);
+}
+
+template <typename Ring, bool is_const>
+template<bool C>
+bool sg14::ring_iterator<Ring, is_const>::operator>(const sg14::ring_iterator<Ring, C>& rhs) const noexcept
+{
+	return (modulo_capacity(m_idx) > rhs.modulo_capacity(m_idx)) && (m_rv == rhs.m_rv);
+}
+
+template <typename Ring, bool is_const>
+template<bool C>
+bool sg14::ring_iterator<Ring, is_const>::operator>=(const sg14::ring_iterator<Ring, C>& rhs) const noexcept
+{
+	return (modulo_capacity(m_idx) > rhs.modulo_capacity(m_idx)) && (m_rv == rhs.m_rv);
 }
 
 template <typename Ring, bool is_const>
@@ -402,7 +438,21 @@ sg14::ring_iterator<Ring, is_const>::ring_iterator(typename sg14::ring_iterator<
 {}
 
 template <typename Ring, bool is_const>
-typename sg14::ring_iterator<Ring, is_const>::size_type sg14::ring_iterator<Ring, is_const>::modulo_capacity(size_type idx) noexcept
+typename sg14::ring_iterator<Ring, is_const>::size_type sg14::ring_iterator<Ring, is_const>::modulo_capacity(size_type idx) const noexcept
 {
 	return idx % m_rv->capacity();
+}
+
+template <typename Ring, bool is_const>
+sg14::ring_iterator<Ring, is_const> operator+(sg14::ring_iterator<Ring, is_const> it, int i) noexcept
+{
+	it += i;
+	return it;
+}
+
+template <typename Ring, bool is_const>
+sg14::ring_iterator<Ring, is_const> operator-(sg14::ring_iterator<Ring, is_const> it, int i) noexcept
+{
+	it -= i;
+	return it;
 }

--- a/SG14/ring.h
+++ b/SG14/ring.h
@@ -336,6 +336,7 @@ void sg14::ring_span<T, Popper>::increase_size() noexcept
 	if (++m_size > m_capacity)
 	{
 		m_size = m_capacity;
+		m_front_idx = (m_front_idx + 1) % m_capacity;
 	}
 }
 


### PR DESCRIPTION
Fix several bugs reported by @paulbendixen on the mailing list:

- Runtime misbehavior in `operator==` and `operator<` (e.g. `for` each element of a full container was unintentionally a no-op)
- Lack of `operator!=`
- Lack of `operator>` `operator>=` `operator<=`
- Lack of `operator+` `operator-`
- Compile error in `cbegin()`
- Runtime misbehavior in `increase_size()` (e.g. as called from `push_back()` on a full container)

(I'm happy to have these four commits cherry-picked in, or merged, or squash-merged; doesn't much matter to me.)