### PR TITLE
`#pragma once` all the things!

### DIFF
--- a/Proposals/ComparingVirtualMethods/cpp_entity_example/stdafx.h
+++ b/Proposals/ComparingVirtualMethods/cpp_entity_example/stdafx.h
@@ -1,9 +1,9 @@
+#pragma once
+
 // stdafx.h : include file for standard system include files,
 // or project specific include files that are used frequently, but
 // are changed infrequently
 //
-
-#pragma once
 
 #ifdef _WIN32
 #include "targetver.h"

--- a/SG14/inplace_function.h
+++ b/SG14/inplace_function.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
  * Boost Software License - Version 1.0 - August 17th, 2003
  *
@@ -23,8 +25,6 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-#pragma once
 
 #include <type_traits>
 #include <functional>

--- a/SG14/plf_colony.h
+++ b/SG14/plf_colony.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Copyright (c) 2016, Matthew Bentley (mattreecebentley@gmail.com) www.plflib.org
 
 // This software is provided 'as-is', without any express or implied

--- a/SG14/plf_stack.h
+++ b/SG14/plf_stack.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Copyright (c) 2016, Matthew Bentley (mattreecebentley@gmail.com) www.plflib.org
 
 // This software is provided 'as-is', without any express or implied

--- a/SG14/ring.h
+++ b/SG14/ring.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstddef>
 #include <type_traits>
 #include <iterator>

--- a/SG14/transcode.h
+++ b/SG14/transcode.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <iterator>
 
 namespace sg14

--- a/SG14_test/SG14_test.h
+++ b/SG14_test/SG14_test.h
@@ -1,5 +1,4 @@
-#if !defined SG14_TEST_2015_06_11_18_24
-#define SG14_TEST_2015_06_11_18_24
+#pragma once
 
 namespace sg14_test
 {
@@ -12,5 +11,3 @@ namespace sg14_test
 	void unstable_remove_test();
 	void uninitialized();
 }
-
-#endif

--- a/SG14_test/plf_benchmark_suite/plf_bench.h
+++ b/SG14_test/plf_benchmark_suite/plf_bench.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef PLF_BENCH_H
 #define PLF_BENCH_H
 

--- a/SG14_test/plf_benchmark_suite/plf_indexed_vector.h
+++ b/SG14_test/plf_benchmark_suite/plf_indexed_vector.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef PLF_INDEXED_VECTOR_H
 #define PLF_INDEXED_VECTOR_H
 

--- a/SG14_test/plf_benchmark_suite/plf_nanotimer.h
+++ b/SG14_test/plf_benchmark_suite/plf_nanotimer.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Copyright (c) 2016, Matthew Bentley (mattreecebentley@gmail.com) www.plflib.org
 
 #ifndef PLF_NANOTIMER

--- a/SG14_test/plf_benchmark_suite/plf_packed_deque.h
+++ b/SG14_test/plf_benchmark_suite/plf_packed_deque.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef PLF_PACKED_DEQUE_H
 #define PLF_PACKED_DEQUE_H
 

--- a/SG14_test/plf_benchmark_suite/plf_pointer_deque.h
+++ b/SG14_test/plf_benchmark_suite/plf_pointer_deque.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef PLF_POINTER_DEQUE_H
 #define PLF_POINTER_DEQUE_H
 


### PR DESCRIPTION
After this change,

    find . -name '*.h' | xargs head -1

shows that every .h file in the repo correctly begins with `#pragma once`.
A few of them have include guards *also*, so the style isn't completely
uniform; but at least none of them are completely unprotected anymore.

Fixes #75.