### PR TITLE
Micro-optimize `unstable_remove`.

### DIFF
--- a/SG14/algorithm_ext.h
+++ b/SG14/algorithm_ext.h
@@ -33,7 +33,6 @@ namespace stdext
 			destruct(Dst, current);
 			throw;
 		}
-
 	}
 
 	template<class FwdIt, class Sentinel>
@@ -80,40 +79,61 @@ namespace stdext
 	BidirIt unstable_remove_if(BidirIt first, BidirIt last, UnaryPredicate p)
 	{
 		while (true) {
-			while ((first != last) && p(*first)) {
+			// Find the first instance of "p"...
+			while (true) {
+				if (first == last) {
+					return first;
+				}
+				if (p(*first)) {
+					break;
+				}
 				++first;
 			}
-			if (first == last) break;
-			--last;
-			while ((first != last) && !p(*last)) {
+			// ...and the last instance of "not p"...
+			while (true) {
 				--last;
+				if (first == last) {
+					return first;
+				}
+				if (!p(*last)) {
+					break;
+				}
 			}
-			if (first == last) break;
+			// ...and move the latter over top of the former.
 			*first = std::move(*last);
 			++first;
 		}
-		return first;
 	}
 
 	template<class BidirIt, class Val>
 	BidirIt unstable_remove(BidirIt first, BidirIt last, const Val& v)
 	{
 		while (true) {
-			while ((first != last) && (*first == v)) {
+			// Find the first instance of "v"...
+			while (true) {
+				if (first == last) {
+					return first;
+				}
+				if (*first == v) {
+					break;
+				}
 				++first;
 			}
-			if (first == last) break;
-			--last;
-			while ((first != last) && !(*last == v)) {
+			// ...and the last instance of "not v"...
+			while (true) {
 				--last;
+				if (first == last) {
+					return first;
+				}
+				if (!(*last == v)) {
+					break;
+				}
 			}
-			if (first == last) break;
+			// ...and move the latter over top of the former.
 			*first = std::move(*last);
 			++first;
 		}
-		return first;
 	}
-
 
 
 	//this exists as a point of reference for providing a stable comparison vs unstable_remove_if

--- a/SG14/algorithm_ext.h
+++ b/SG14/algorithm_ext.h
@@ -96,7 +96,7 @@ namespace stdext
 	}
 
 	template<class BidirIt, class Val>
-	BidirIt unstable_remove(BidirIt first, BidirIt last, Val v)
+	BidirIt unstable_remove(BidirIt first, BidirIt last, const Val& v)
 	{
 		while (true) {
 			while ((first != last) && (*first == v)) {

--- a/SG14/algorithm_ext.h
+++ b/SG14/algorithm_ext.h
@@ -54,9 +54,8 @@ namespace stdext
 			destruct(first, current);
 			throw;
 		}
-
 	}
-	
+
 	template<class FwdIt, class Sentinel>
 	FwdIt uninitialized_default_construct(FwdIt first, Sentinel last)
 	{
@@ -80,32 +79,37 @@ namespace stdext
 	template<class BidirIt, class UnaryPredicate>
 	BidirIt unstable_remove_if(BidirIt first, BidirIt last, UnaryPredicate p)
 	{
-		while (1) {
+		while (true) {
 			while ((first != last) && p(*first)) {
 				++first;
 			}
-			if (first == last--) break;
+			if (first == last) break;
+			--last;
 			while ((first != last) && !p(*last)) {
 				--last;
 			}
 			if (first == last) break;
-			*first++ = std::move(*last);
+			*first = std::move(*last);
+			++first;
 		}
 		return first;
 	}
+
 	template<class BidirIt, class Val>
 	BidirIt unstable_remove(BidirIt first, BidirIt last, Val v)
 	{
-		while (1) {
+		while (true) {
 			while ((first != last) && (*first == v)) {
 				++first;
 			}
-			if (first == last--) break;
+			if (first == last) break;
+			--last;
 			while ((first != last) && !(*last == v)) {
 				--last;
 			}
 			if (first == last) break;
-			*first++ = std::move(*last);
+			*first = std::move(*last);
+			++first;
 		}
 		return first;
 	}
@@ -116,16 +120,18 @@ namespace stdext
 	template<class BidirIt, class UnaryPredicate>
 	BidirIt partition(BidirIt first, BidirIt last, UnaryPredicate p)
 	{
-		while (1) {
+		while (true) {
 			while ((first != last) && p(*first)) {
 				++first;
 			}
-			if (first == last--) break;
+			if (first == last) break;
+			--last;
 			while ((first != last) && !p(*last)) {
 				--last;
 			}
 			if (first == last) break;
-			std::iter_swap(first++, last);
+			std::iter_swap(first, last);
+			++first;
 		}
 		return first;
 	}
@@ -135,10 +141,14 @@ namespace stdext
 	ForwardIt remove_if(ForwardIt first, ForwardIt last, UnaryPredicate p)
 	{
 		first = std::find_if(first, last, p);
-		if (first != last)
-			for (ForwardIt i = first; ++i != last; )
-				if (!p(*i))
-					*first++ = std::move(*i);
+		if (first != last) {
+			for (ForwardIt i = first; ++i != last; ) {
+				if (!p(*i)) {
+					*first = std::move(*i);
+					++first;
+				}
+			}
+		}
 		return first;
 	}
 }


### PR DESCRIPTION
As usual, I offer a pull request consisting of several patches, and don't mind if you don't take all of them (but of course I advise taking all of them).

The third patch here is the most invasive yet the most beneficial IMHO; by removing a bunch of redundant comparisons, it speeds up `unstable_remove` at `clang++ -O0` to the point where it can actually beat `std::remove`.