### PR TITLE
SG14_test build fixes

### DIFF
--- a/SG14_test/ring_test.cpp
+++ b/SG14_test/ring_test.cpp
@@ -103,7 +103,7 @@ static void filter_test()
 
 	assert( buffer.front() == 2.0 );
 
-	constexpr std::array< double, 3 > filter_coefficients = { 0.25, 0.5, 0.25 };
+	constexpr std::array< double, 3 > filter_coefficients = {{ 0.25, 0.5, 0.25 }};
 
 	// In an update loop, interrupt routine or the like
 	buffer.push_back( 7.0 );

--- a/SG14_test/unstable_remove_test.cpp
+++ b/SG14_test/unstable_remove_test.cpp
@@ -55,16 +55,18 @@ void sg14_test::unstable_remove_test()
 		return (t1 - t0).count();
 	};
 
-	auto median = [](std::vector<unsigned long>& v)
+	using time_lambda_t = decltype(time(removefn));
+
+	auto median = [](std::vector<time_lambda_t>& v)
 	{
 		auto b = v.begin();
 		auto e = v.end();
 		return *(b + ((e - b) / 2));
 	};
 
-	std::vector<unsigned long> partition; 
-	std::vector<unsigned long> unstable_remove_if;
-	std::vector<unsigned long> remove_if;
+	std::vector<time_lambda_t> partition;
+	std::vector<time_lambda_t> unstable_remove_if;
+	std::vector<time_lambda_t> remove_if;
 
 	partition.reserve(test_runs);
 	unstable_remove_if.reserve(test_runs);

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -19,6 +19,8 @@ endif()
 set(SG14_SOURCE_DIRECTORY "../SG14")
 set(SG14_TEST_SOURCE_DIRECTORY "../SG14_test")
 
+find_package(Threads REQUIRED)
+
 set(SOURCE_FILES
     ${SG14_TEST_SOURCE_DIRECTORY}/main.cpp
     ${SG14_TEST_SOURCE_DIRECTORY}/SG14_test.cpp
@@ -35,6 +37,6 @@ add_executable(sg14 ${SOURCE_FILES})
 
 include_directories("${SG14_SOURCE_DIRECTORY}" "${SG14_TEST_SOURCE_DIRECTORY}")
 
-target_link_libraries(sg14)
-# "dl" "pthread" "stdc++" "m")
+target_link_libraries(sg14 "${CMAKE_THREAD_LIBS_INIT}")
+# "dl" "stdc++" "m")
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,12 +1,20 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(sg14)
 
+if(MSVC)
+set(WARNING_FLAGS "/W4 /WX")
+else()
 set(WARNING_FLAGS "-Wall -Wextra -Wfatal-errors -Werror")
+endif()
 
+if(MSVC)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS} -D_SCL_SECURE_NO_WARNINGS")
+else()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS} -std=c++14")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG -fno-rtti -Ofast")
 set(CMAKE_EXE_LINKER_FLAGS "-g")
+endif()
 
 set(SG14_SOURCE_DIRECTORY "../SG14")
 set(SG14_TEST_SOURCE_DIRECTORY "../SG14_test")


### PR DESCRIPTION
A quick set of build-fixes for the SG14_test code and CMake build system.

Tested with:
* MSVC2015
* MSVC2017
* gcc 6.3.0 (mingw64 from MSYS2)
* clang 3.9.1 (mingw64 from MSYS2)

This doesn't fix the builds completely, but other fixes need to be done in the SG14 library itself, and I want to keep those separated, and ideally unit-tested.