### PR TITLE
Several cleanups to "ring.h".

### DIFF
--- a/SG14_test/SG14_test.cpp
+++ b/SG14_test/SG14_test.cpp
@@ -7,10 +7,11 @@
 
 #include <cassert>
 
+
+#if 0
 void sg14_test::static_ring_test()
 {
     assert(!"Please check in definition of sg14::static_ring.");
-#if 0
 	sg14::static_ring<int, 5> Q;
 
 	Q.push(7);
@@ -54,14 +55,14 @@ void sg14_test::static_ring_test()
 	assert(Q5.size() == 5);
 	assert(Q5.front() == 6);
 	assert(Q5.back() == 10);
-#endif
 }
+#endif
 
 
+#if 0
 void sg14_test::dynamic_ring_test()
 {
     assert(!"Please check in definition of sg14::dynamic_ring.");
-#if 0
 	sg14::dynamic_ring<int> Q(8);
 
 	assert(Q.push(7));
@@ -105,5 +106,5 @@ void sg14_test::dynamic_ring_test()
 	assert(Q5.size() == 5);
 	assert(Q5.front() == 6);
 	assert(Q5.back() == 10);
-#endif
 }
+#endif

--- a/SG14_test/SG14_test.h
+++ b/SG14_test/SG14_test.h
@@ -5,13 +5,9 @@ namespace sg14_test
 {
     void inplace_function_test();
     void transcode_test();
-    void ring_test();
-    void static_ring_test();
-    void dynamic_ring_test();
-	void thread_communication_test();
-	void filter_test();
-	void unstable_remove_test();
-	void uninitialized();
+    void ring_tests();
+    void unstable_remove_test();
+    void uninitialized();
 }
 
 #endif

--- a/SG14_test/main.cpp
+++ b/SG14_test/main.cpp
@@ -10,14 +10,11 @@ int main(int, char *[])
 {
     sg14_test::inplace_function_test();
     sg14_test::transcode_test();
-    sg14_test::ring_test();
-    sg14_test::thread_communication_test();
-    sg14_test::filter_test();
+    sg14_test::ring_tests();
     sg14_test::unstable_remove_test();
-	sg14_test::uninitialized();
+    sg14_test::uninitialized();
 
-	puts("tests completed");
+    puts("tests completed");
 
-	return 0;
+    return 0;
 }
-

--- a/SG14_test/ring_test.cpp
+++ b/SG14_test/ring_test.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <numeric>
 
-void sg14_test::ring_test()
+static void ring_test()
 {
 	std::array<int, 5> A;
 	std::array<int, 5> B;
@@ -52,7 +52,7 @@ void sg14_test::ring_test()
 	puts("Ring test completed.\n");
 }
 
-void sg14_test::thread_communication_test()
+static void thread_communication_test()
 {
 	std::array<int, 10> A;
 	sg14::ring_span<int> buffer(std::begin(A), std::end(A));
@@ -91,7 +91,7 @@ void sg14_test::thread_communication_test()
 	});
 }
 
-void sg14_test::filter_test()
+static void filter_test()
 {
 	std::array< double, 3 > A;
 	sg14::ring_span< double > buffer( std::begin( A ), std::end( A ) );
@@ -110,4 +110,50 @@ void sg14_test::filter_test()
 
 	assert( std::inner_product( buffer.begin(), buffer.end(), filter_coefficients.begin(), 0.0 ) == 5.0 );
 	puts( "Filter example completed.\n" );
+}
+
+static void iterator_regression_test()
+{
+    std::array<double, 3> A;
+    sg14::ring_span<double> r(A.begin(), A.end());
+    r.push_back(1.0);
+    decltype(r)::iterator it = r.end();
+    decltype(r)::const_iterator cit = r.end();  // test conversion from non-const to const
+    assert(it == cit);  // test comparison of const and non-const
+    assert(it + 0 == it);
+    assert(it - 1 == r.begin());
+    assert(cit + 0 == cit);
+    assert(cit - 1 == r.cbegin());
+    assert(it - cit == 0);
+    assert(cit - r.begin() == 1);
+
+    std::array<double, 4> B;
+    sg14::ring_span<double> r2(B.begin(), B.end());
+    swap(r, r2);  // test existence of ADL swap()
+
+    // Set up the ring for the TEST_OP tests below.
+    r = sg14::ring_span<double>(A.begin(), A.end(), A.begin(), 2);
+    assert(r.size() == 2);
+
+#define TEST_OP(op, a, b, c) \
+    assert(a(r.begin() op r.end())); \
+    assert(b(r.end() op r.begin())); \
+    assert(c(r.begin() op r.begin()))
+#define _
+    TEST_OP(==, !, !, _);
+    TEST_OP(!=, _, _, !);
+    TEST_OP(<, _, !, !);
+    TEST_OP(<=, _, !, _);
+    TEST_OP(>, !, _, !);
+    TEST_OP(>=, !, _, _);
+#undef _
+#undef TEST_OP
+}
+
+void sg14_test::ring_tests()
+{
+    ring_test();
+    thread_communication_test();
+    filter_test();
+    iterator_regression_test();
 }


### PR DESCRIPTION
- Add `#pragma once`.
- Add a non-member ADL swap() for rings.
- Fix up the namespace of operator+= and operator-= for ring iterators.
- Fix up (it + n) and (it - n) for ring iterators.
- Add (it - it) for ring iterators.
- Fix a typo in (a >= b) for ring iterators, and make (a <= b) == !(b > a).
- Add the implicit conversion from iterator to const_iterator.
- `#if 0` the broken tests for unimplemented static_ring and dynamic_ring.

Fixes #75, #77, #90, #93, #101.

Ping @hatcat, @TBBle.