### PR TITLE
Suppress 'unused parameter' warnings for plf test suite

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -32,6 +32,17 @@ set(SOURCE_FILES
     ${SG14_TEST_SOURCE_DIRECTORY}/transcode_test.cpp
     ${SG14_TEST_SOURCE_DIRECTORY}/uninitialized.cpp)
 
+if(MSVC)
+set(SG14_IGNORE_UNUSED_PARAMETER "/wd4100")
+else()
+set(SG14_IGNORE_UNUSED_PARAMETER "-Wno-unused-parameter")
+endif()
+set_source_files_properties(${SG14_TEST_SOURCE_DIRECTORY}/plf_stack_test_suite.cpp PROPERTIES
+	COMPILE_FLAGS ${SG14_IGNORE_UNUSED_PARAMETER}
+)
+set_source_files_properties(${SG14_TEST_SOURCE_DIRECTORY}/plf_colony_test_suite.cpp PROPERTIES
+	COMPILE_FLAGS ${SG14_IGNORE_UNUSED_PARAMETER}
+)
 
 add_executable(sg14 ${SOURCE_FILES})
 


### PR DESCRIPTION
By some magic, this also suppresses a couple of other warnings in MSVC, triggered by the plf colony test suite.
* C4456: declaration of 'the_iterator' hides previous local declaration
* C4267: 'initializing': conversion from 'size_t' to 'unsigned short', possible loss of data

I _suspect_ these other warnings are normally suppressed unless another warning in the same file is triggered.

Broken out of #95 due to allow further discussion.