### PR TITLE
Fix behavior of ring_span's copy_popper<T>, and general popper cleanup.

### DIFF
--- a/SG14/ring.h
+++ b/SG14/ring.h
@@ -10,21 +10,22 @@ namespace sg14
 	template <typename T>
 	struct null_popper
 	{
-		void operator()(T&);
+		void operator()(T&) const noexcept;
 	};
 
 	template <typename T>
 	struct default_popper
 	{
-		T operator()(T& t);
+		T operator()(T& t) const;
 	};
 
 	template <typename T>
 	struct copy_popper
 	{
-		copy_popper(T&& t);
-		T operator()(T& t);
-		T copy;
+		explicit copy_popper(T t);
+		T operator()(T& t) const;
+	private:
+		T m_copy;
 	};
 
 	template <typename, bool>
@@ -157,26 +158,27 @@ namespace sg14
 // Sample implementation
 
 template <typename T>
-void sg14::null_popper<T>::operator()(T&)
+void sg14::null_popper<T>::operator()(T&) const noexcept
 {}
 
 template <typename T>
-T sg14::default_popper<T>::operator()(T& t)
+T sg14::default_popper<T>::operator()(T& t) const
 {
 	return std::move(t);
 }
 
 template <typename T>
-sg14::copy_popper<T>::copy_popper(T&& t)
-	: copy(std::move(t))
+sg14::copy_popper<T>::copy_popper(T t)
+	: m_copy(std::move(t))
 {}
 
 template <typename T>
-T sg14::copy_popper<T>::operator()(T& t)
+T sg14::copy_popper<T>::operator()(T& t) const
 {
-	T old = t;
-	t = copy;
-	return t;
+	T old = m_copy;
+	using std::swap;
+	swap(old, t);
+	return old;
 }
 
 template<typename T, class Popper>

--- a/SG14_test/ring_test.cpp
+++ b/SG14_test/ring_test.cpp
@@ -7,6 +7,8 @@
 #include <future>
 #include <iostream>
 #include <numeric>
+#include <string>
+#include <vector>
 
 static void ring_test()
 {
@@ -150,10 +152,24 @@ static void iterator_regression_test()
 #undef TEST_OP
 }
 
+static void copy_popper_test()
+{
+    std::vector<std::string> v { "quick", "brown", "fox" };
+    sg14::ring_span<std::string, sg14::copy_popper<std::string>> r(v.begin(), v.end(), {"popped"});
+    r.emplace_back("slow");
+    assert((v == std::vector<std::string>{"slow", "brown", "fox"}));
+    r.emplace_back("red");
+    assert((v == std::vector<std::string>{"slow", "red", "fox"}));
+    std::string result = r.pop_front();
+    assert((v == std::vector<std::string>{"popped", "red", "fox"}));
+    assert(result == "slow");
+}
+
 void sg14_test::ring_tests()
 {
     ring_test();
     thread_communication_test();
     filter_test();
     iterator_regression_test();
+    copy_popper_test();
 }


### PR DESCRIPTION
Fixes #91. Apparently the typo `t` for `old` is also in the current
paper http://wg21.link/p0059r3 — we should fix that too!

Fixes #102.