### PR TITLE
Bugfixes and a better test harness for stdext::inplace_function

### DIFF
--- a/SG14_test/inplace_function_test.cpp
+++ b/SG14_test/inplace_function_test.cpp
@@ -1,61 +1,93 @@
 #include "SG14_test.h"
 #include "../SG14/inplace_function.h"
-#include <iostream>
+#include <cassert>
 
-namespace
+namespace {
+
+static int copied, moved, called_with;
+static int expected;
+
+struct Functor {
+    Functor() {}
+    Functor(const Functor&) { copied += 1; }
+    Functor(Functor&&) { moved += 1; }
+    void operator()(int i) { assert(i == expected); called_with = i; }
+};
+
+struct ConstFunctor {
+    ConstFunctor() {}
+    ConstFunctor(const ConstFunctor&) { copied += 1; }
+    ConstFunctor(ConstFunctor&&) { moved += 1; }
+    void operator()(int i) const { assert(i == expected); called_with = i; }
+};
+
+void Foo(int i)
 {
-	struct Functor
-	{
-		Functor() {}
-		Functor(const Functor&) { std::cout << "copy" << std::endl; }
-		Functor(Functor&&) { std::cout << "move" << std::endl; }
-		void operator()()
-		{
-			std::cout << "functor" << std::endl;
-		}
-	};
-
-	void Foo()
-	{
-		std::cout << "foo" << std::endl;
-	}
-
-	template <typename T>
-	void SomeTest()
-	{
-		T func = [] { std::cout << "lambda" << std::endl; };
-		func();
-		std::cout << "func = &Foo" << std::endl;
-		func = &Foo;
-		func();
-		std::cout << "T func2 = Functor()" << std::endl;
-		T func2 = Functor();
-		std::cout << "func.swap(func2)" << std::endl;
-
-		// with inplace_function, this cannot simply swap pointers
-		func.swap(func2);
-	}
+    assert(i == expected);
+    called_with = i;
 }
 
-namespace sg14_test
+} // anonymous namespace
+
+void sg14_test::inplace_function_test()
 {
-	void inplace_function_test()
-	{
-		stdext::inplace_function<void()> func = [] { std::cout << "lambda" << std::endl; };
-		func();
-		func = &Foo;
-		func();
-		stdext::inplace_function<void()> func2 = Functor();
-		func.swap(func2);
+    using IPF = stdext::inplace_function<void(int)>;
+    static_assert(std::is_nothrow_default_constructible<IPF>::value, "");
+    static_assert(std::is_copy_constructible<IPF>::value, "");
+    static_assert(std::is_move_constructible<IPF>::value, "");
+    static_assert(std::is_copy_assignable<IPF>::value, "");
+    static_assert(std::is_move_assignable<IPF>::value, "");
+    // static_assert(std::is_swappable<IPF&>::value, "");  // C++17
+    static_assert(std::is_nothrow_destructible<IPF>::value, "");
 
-		std::cout << "\nSomeTest<std::function<void()>>" << std::endl;
-		SomeTest<std::function<void()>>();
+    IPF func;
+    assert(!func);
+    assert(!bool(func));
+    assert(func == nullptr);
+    assert(!(func != nullptr));
+    expected = 0; try { func(42); } catch (std::bad_function_call&) { expected = 1; } assert(expected == 1);
 
-		std::cout << "\nSomeTest<inplace_function<void()>>" << std::endl;
-		SomeTest<stdext::inplace_function<void()>>();
+    func = Foo;
+    assert(!!func);
+    assert(func);
+    assert(!(func == nullptr));
+    assert(func != nullptr);
+    called_with = 0; expected = 42; func(42); assert(called_with == 42);
 
-		std::cout << std::boolalpha << "\nSomeTest " << (func == nullptr) << std::endl;
-	}
+    func = nullptr;
+    assert(!func);
+    assert(!bool(func));
+    assert(func == nullptr);
+    assert(!(func != nullptr));
+    expected = 0; try { func(42); } catch (std::bad_function_call&) { expected = 1; } assert(expected == 1);
+
+    using IPF40 = stdext::inplace_function<void(int), 40>; // the default is 32
+    static_assert(std::is_constructible<IPF40, const IPF&>::value, "");
+    static_assert(std::is_constructible<IPF40, IPF&&>::value, "");  // TODO: nothrow
+    static_assert(std::is_assignable<IPF40&, const IPF&>::value, "");
+    static_assert(std::is_assignable<IPF40&, IPF&&>::value, "");  // TODO: nothrow
+    // static_assert(!std::is_assignable<IPF&, const IPF40&>::value, "");  // TODO: SFINAE
+    // static_assert(!std::is_assignable<IPF&, IPF40&&>::value, "");  // TODO: SFINAE
+    // static_assert(!std::is_swappable_with<IPF40&, IPF&>::value, ""); // C++17
+    // static_assert(!std::is_swappable_with<IPF&, IPF40&>::value, ""); // C++17
+    static_assert(std::is_nothrow_destructible<IPF40>::value, "");
+
+    IPF40 func40;
+    assert(!func40);
+    assert(!bool(func40));
+    assert(func40 == nullptr);
+    assert(!(func40 != nullptr));
+    expected = 0; try { func40(42); } catch (std::bad_function_call&) { expected = 1; } assert(expected == 1);
+
+    func = nullptr;
+    func40 = func;
+#if 0  // TODO: this is a bug
+    assert(!func40);
+    assert(!bool(func40));
+    assert(func40 == nullptr);
+    assert(!(func40 != nullptr));
+#endif
+    expected = 0; try { func40(42); } catch (std::bad_function_call&) { expected = 1; } assert(expected == 1);
 }
 
 #ifdef TEST_MAIN


### PR DESCRIPTION
This includes a mass renaming of template parameters so that all the type parameters are named "FooT" and all the non-type parameters are named "Foo" (no "T").

This also includes the fix for #111.

However, I've found another problem with the conversion from `inplace_function<Sig, Sz>` to `inplace_function<Sig, LargerSz>` — namely, if the source is the "empty" function object, then the destination receives a function object that it doesn't recognize as "empty".