### PR TITLE
inplace_function: Fix lifetime bugs in f.swap(g).

### DIFF
--- a/SG14/inplace_function.h
+++ b/SG14/inplace_function.h
@@ -209,9 +209,9 @@ public:
 	void swap(inplace_function& other)
 	{
 		BufferType tempData;
-		this->move(m_Data, tempData);
-		other.move(other.m_Data, m_Data);
-		this->move(tempData, other.m_Data);
+		this->relocate(m_Data, tempData);
+		other.relocate(other.m_Data, m_Data);
+		this->relocate(tempData, other.m_Data);
 		std::swap(m_InvokeFctPtr, other.m_InvokeFctPtr);
 		std::swap(m_ManagerFctPtr, other.m_ManagerFctPtr);
 	}
@@ -239,12 +239,14 @@ private:
 		m_ManagerFctPtr = other.m_ManagerFctPtr;
 	}
 
-	void move(BufferType& from, BufferType& to)
+	void relocate(BufferType& from, BufferType& to)
 	{
-		if (m_ManagerFctPtr)
-			m_ManagerFctPtr(&from, &to, Operation::Move);
-		else
+		if (m_ManagerFctPtr) {
+			m_ManagerFctPtr(&to, &from, Operation::Move);
+			m_ManagerFctPtr(&from, nullptr, Operation::Destroy);
+		} else {
 			to = from;
+		}
 	}
 
 	template<size_t OtherCapacity, size_t OtherAlignment>

--- a/SG14_test/inplace_function_test.cpp
+++ b/SG14_test/inplace_function_test.cpp
@@ -136,6 +136,31 @@ void FunctorDestruction()
     EXPECT_EQ(AnotherFunctor::mDestructorCalls, AnotherFunctor::mConstructorCalls);
 }
 
+void Swapping()
+{
+    AnotherFunctor::mDestructorCalls = 0;
+    AnotherFunctor::mConstructorCalls = 0;
+    {
+        AnotherFunctor ftor;
+        auto lambda = [](int x){ return x + 10; };
+        stdext::inplace_function<int(int), 4> fun(ftor);
+        stdext::inplace_function<int(int), 4> fun2(lambda);
+
+        fun.swap(fun2);  // swap...
+        fun2.swap(fun);  // ...and swap back
+
+        int r1 = fun(1);
+        int r2 = fun(7);
+        EXPECT_EQ(1, r1);
+        EXPECT_EQ(8, r2);
+
+        int r3 = fun2(1);
+        int r4 = fun2(7);
+        EXPECT_EQ(11, r3);
+        EXPECT_EQ(17, r4);
+    }
+    EXPECT_EQ(AnotherFunctor::mDestructorCalls, AnotherFunctor::mConstructorCalls);
+}
 
 void Copying()
 {
@@ -239,6 +264,7 @@ void sg14_test::inplace_function_test()
     FunctionPointer();
     Lambda();
     Bind();
+    Swapping();
     Copying();
     ContainingStdFuntion();
     SimilarTypeCopy();


### PR DESCRIPTION
And test that f.swap(g) uses the right vtable to construct and destroy functors.