### PR TITLE
Improve the struct layout of inplace_function<Sig, 8>.

### DIFF
--- a/SG14/inplace_function.h
+++ b/SG14/inplace_function.h
@@ -36,15 +36,6 @@ namespace detail {
 
 static constexpr size_t InplaceFunctionDefaultCapacity = 32;
 
-using default_storage_t = std::aligned_storage_t<
-    InplaceFunctionDefaultCapacity
->;
-
-static constexpr size_t InplaceFunctionDefaultAlignment = std::alignment_of<
-    default_storage_t
->::value;
-
-
 template<typename T> struct wrapper
 {
     using type = T;
@@ -123,9 +114,9 @@ struct is_valid_inplace_dst : std::true_type
 } // namespace detail
 
 template<
-    typename,
+    typename Signature,
     size_t Capacity = detail::InplaceFunctionDefaultCapacity,
-    size_t Alignment = detail::InplaceFunctionDefaultAlignment
+    size_t Alignment = std::alignment_of<std::aligned_storage_t<Capacity>>::value
 >
 class inplace_function; // unspecified
 

--- a/SG14_test/inplace_function_test.cpp
+++ b/SG14_test/inplace_function_test.cpp
@@ -283,6 +283,14 @@ void sg14_test::inplace_function_test()
     //static_assert(std::is_swappable<IPF&>::value, "");  // C++17
     static_assert(std::is_nothrow_destructible<IPF>::value, "");
 
+    constexpr int alignof_ptr = std::alignment_of<void*>::value;
+    static_assert(std::alignment_of< stdext::inplace_function<void(int), 1> >::value == std::max(1, alignof_ptr), "");
+    static_assert(std::alignment_of< stdext::inplace_function<void(int), 2> >::value == std::max(2, alignof_ptr), "");
+    static_assert(std::alignment_of< stdext::inplace_function<void(int), 4> >::value == std::max(4, alignof_ptr), "");
+    static_assert(std::alignment_of< stdext::inplace_function<void(int), 8> >::value == std::max(8, alignof_ptr), "");
+    static_assert(std::alignment_of< stdext::inplace_function<void(int), 16> >::value == std::max(16, alignof_ptr), "");
+    static_assert(sizeof( stdext::inplace_function<void(int), sizeof(void*)> ) == 2 * sizeof(void*), "");
+
     IPF func;
     assert(!func);
     assert(!bool(func));


### PR DESCRIPTION
Attn @carlcook, @Voultapher: this is an ABI-breaking change but I believe it's important to fix.

Before this patch, `inplace_function<Sig, 8>` implicitly meant
`inplace_function<Sig, 8, DefaultAlignment>`, which was
`inplace_function<Sig, 8, 16>` on my MacBook (at least).

After this patch, `inplace_function<Sig, Cap>` implicitly has
the same alignment requirements as `aligned_storage_t<Cap>` (plus
the alignment requirements of the internal vtable pointer type).