### PR TITLE
slot_map: The free list should be LIFO, not FIFO

### DIFF
--- a/SG14/slot_map.h
+++ b/SG14/slot_map.h
@@ -213,14 +213,19 @@ public:
     // Functions for accessing and modifying the size of the slots container.
     // These are beneficial as allocating more slots than values will cause the
     // generation counter increases to be more evenly distributed across the slots.
-    // TODO [ajo]: The above comment is false, at least for this implementation.
     //
     constexpr void reserve_slots(size_type n) {
         slot_map_detail::reserve_if_possible(slots_, n);
-        while (slots_.size() < n) {
-            auto idx = next_available_slot_index_;
-            next_available_slot_index_ = static_cast<key_size_type>(slots_.size());
-            slots_.emplace_back(key_type{idx, key_generation_type{}});
+        key_size_type original_num_slots = slots_.size();
+        if (original_num_slots < n) {
+            slots_.emplace_back(key_type{next_available_slot_index_, key_generation_type{}});
+            key_size_type last_new_slot = original_num_slots;
+            --n;
+            while (last_new_slot != n) {
+                slots_.emplace_back(key_type{last_new_slot, key_generation_type{}});
+                ++last_new_slot;
+            }
+            next_available_slot_index_ = last_new_slot;
         }
     }
     constexpr size_type slot_count() const { return slots_.size(); }
@@ -239,9 +244,15 @@ public:
         if (next_available_slot_index_ == slots_.size()) {
             auto idx = next_available_slot_index_; ++idx;
             slots_.emplace_back(key_type{idx, key_generation_type{}});  // make a new slot
+            last_available_slot_index_ = idx;
         }
         auto slot_iter = std::next(slots_.begin(), next_available_slot_index_);
-        next_available_slot_index_ = this->get_index(*slot_iter);
+        if (next_available_slot_index_ == last_available_slot_index_) {
+            next_available_slot_index_ = slots_.size();
+            last_available_slot_index_ = next_available_slot_index_;
+        } else {
+            next_available_slot_index_ = this->get_index(*slot_iter);
+        }
         this->set_index(*slot_iter, value_pos);
         this->increment_generation(*slot_iter);
         key_type result = *slot_iter;
@@ -289,6 +300,7 @@ public:
         values_.clear();
         reverse_map_.clear();
         next_available_slot_index_ = key_size_type{};
+        last_available_slot_index_ = key_size_type{};
     }
 
     // swap is not mentioned in P0661r1 but it should be.
@@ -298,6 +310,7 @@ public:
         swap(values_, rhs.values_);
         swap(reverse_map_, rhs.reverse_map_);
         swap(next_available_slot_index_, rhs.next_available_slot_index_);
+        swap(last_available_slot_index_, rhs.last_available_slot_index_);
     }
 
 protected:
@@ -329,9 +342,15 @@ private:
         values_.pop_back();
         reverse_map_.pop_back();
         // Expire this key.
-        this->set_index(*slot_iter, next_available_slot_index_);
+        if (next_available_slot_index_ == slots_.size()) {
+            next_available_slot_index_ = static_cast<key_size_type>(slot_index);
+            last_available_slot_index_ = static_cast<key_size_type>(slot_index);
+        } else {
+            auto last_slot_iter = std::next(slots_.begin(), last_available_slot_index_);
+            this->set_index(*last_slot_iter, slot_index);
+            last_available_slot_index_ = static_cast<key_size_type>(slot_index);
+        }
         this->increment_generation(*slot_iter);
-        next_available_slot_index_ = static_cast<key_size_type>(slot_index);
         return std::next(values_.begin(), value_index);
     }
 
@@ -339,6 +358,14 @@ private:
     Container<key_size_type> reverse_map_;  // exactly size() entries
     Container<mapped_type> values_;  // exactly size() entries
     key_size_type next_available_slot_index_{};
+    key_size_type last_available_slot_index_{};
+
+    // Class invariant:
+    // Either next_available_slot_index_ == last_available_slot_index_ == slots_.size(),
+    // or else 0 <= next_available_slot_index_ < slots_.size() and the "key" of that slot
+    // entry points to the subsequent available slot, and so on, until reaching
+    // last_available_slot_index_ (which might equal next_available_slot_index_ if there
+    // is only one available slot at the moment).
 };
 
 template<class T, class Key, template<class...> class Container>


### PR DESCRIPTION
This is mentioned at the end of Allan's paper
http://open-std.org/JTC1/SC22/WG21/docs/papers/2017/p0661r0.pdf

> Alternatively, the free list could store both a front and back index
> on the container, providing the ability to cycle through free slots
> more uniformly, reducing the chance of a generation counter overflow
> occurring. This is a quite valuable benefit with low overhead,
> so explicitly requiring it seems worthwhile.

I'm not 100% sure that this is the best or most efficient (or most correct) way to actually write the code, though.