### PR TITLE
CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,133 @@
+language: cpp
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew update;
+      brew upgrade cmake;
+      brew install cmake;
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      eval "${MATRIX_EVAL}";
+      DEPS_DIR="${TRAVIS_BUILD_DIR}/deps";
+      mkdir ${DEPS_DIR} && cd ${DEPS_DIR};
+      CMAKE_URL="https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.tar.gz";
+      mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake;
+      export PATH=${DEPS_DIR}/cmake/bin:${PATH};
+      cd ..;
+    fi
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode9.2
+      env:
+        - CONFIG=Release
+
+    - os: osx
+      osx_image: xcode9.2
+      env:
+        - CONFIG=Debug
+
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - g++-5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && CONFIG=Debug"
+
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - g++-5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5 && CONFIG=Release"
+
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6 && CONFIG=Debug"
+
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6 && CONFIG=Release"
+
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CONFIG=Debug"
+
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CONFIG=Release"
+
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-8
+            - g++-8
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8 && CONFIG=Debug"
+
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-8
+            - g++-8
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8 && CONFIG=Release"
+
+script:
+  - mkdir build && cd build && cmake .. && cmake --build . && ./bin/sg14_tests
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,11 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	set_source_files_properties(${SG14_TEST_SOURCE_DIRECTORY}/plf_colony_test.cpp PROPERTIES
 		COMPILE_FLAGS "-Wno-unused-parameter"
 	)
+	if (CMAKE_CXX_COMPILER_VERSION MATCHES "^7.*")
+		set_source_files_properties(${SG14_TEST_SOURCE_DIRECTORY}/slot_map_test.cpp PROPERTIES
+			COMPILE_FLAGS "-Wno-error=unused-variable -Wno-error=unused-but-set-variable") # Fix gcc7 issues with structured bindings
+		message("Disabled -Wunused-variable and -Wunused-but-set-variable for gcc ${CMAKE_CXX_COMPILER_VERSION}.")
+	endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${TEST_NAME})
 	target_compile_options(${TEST_NAME} PRIVATE /Zc:__cplusplus /permissive- /W4 /WX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,12 +61,9 @@ target_include_directories(${TEST_NAME} PRIVATE "${SG14_TEST_SOURCE_DIRECTORY}")
 
 # Compile options
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-	target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -Wfatal-errors -Werror)
-	set_source_files_properties(${SG14_TEST_SOURCE_DIRECTORY}/plf_colony_test.cpp PROPERTIES
-		COMPILE_FLAGS "-Wno-unused-parameter"
-	)
+	target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -Werror)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -Wfatal-errors -Werror)
+	target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -Werror)
 	set_source_files_properties(${SG14_TEST_SOURCE_DIRECTORY}/plf_colony_test.cpp PROPERTIES
 		COMPILE_FLAGS "-Wno-unused-parameter"
 	)
@@ -80,6 +77,5 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	target_compile_options(${TEST_NAME} PRIVATE /Zc:__cplusplus /permissive- /W4 /WX)
 	add_definitions(-DNOMINMAX -D_SCL_SECURE_NO_WARNINGS)
 	set_source_files_properties(${SG14_TEST_SOURCE_DIRECTORY}/plf_colony_test.cpp PROPERTIES
-		COMPILE_FLAGS "/wd4100 /wd4456 /wd4127"
-	)
+		COMPILE_FLAGS "/wd4127") # Disable conditional expression is constant, use if constexpr
 endif()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # SG14
+[![Build Status](https://travis-ci.org/WG21-SG14/SG14.svg?branch=master)](https://travis-ci.org/WG21-SG14/SG14)
+
 A library for Study Group 14 of Working Group 21 (C++)
 
 /docs - Documentation for implementations without proposals, or supplementary documentation which does not easily fit within a proposal.

--- a/SG14_test/SG14_test.h
+++ b/SG14_test/SG14_test.h
@@ -1,6 +1,8 @@
 #if !defined SG14_TEST_2015_06_11_18_24
 #define SG14_TEST_2015_06_11_18_24
 
+#undef NDEBUG
+
 namespace sg14_test
 {
     void inplace_function_test();

--- a/SG14_test/plf_colony_test.cpp
+++ b/SG14_test/plf_colony_test.cpp
@@ -119,12 +119,11 @@
 #endif
 
 
-
-#include <functional> // std::greater
-#include <vector> // range-insert testing
 #include <algorithm> // std::find
 #include <cstdio> // log redirection, printf
 #include <cstdlib> // abort
+#include <functional> // std::greater
+#include <vector> // range-insert testing
 
 #ifdef PLF_MOVE_SEMANTICS_SUPPORT
 	#include <utility> // std::move
@@ -146,11 +145,11 @@ namespace
         }
     }
 
-	void title1(const char *title_text)
+	void title1(const char *)
 	{
 	}
 
-	void title2(const char *title_text)
+	void title2(const char *)
 	{
 	}
 


### PR DESCRIPTION
Enables CI and testing with gcc 5, 6, 7, 8 (linux), clang 4.0.x (macos), msvc 2017 (win). Both debug and release builds are tested.

To whomever may merge : You will need to add the repo on travis and appveyor. Once that is done, the readme should be updated with your badge links as well.

New commits or PRs will trigger CI automatically.

Some changes of note:
- The threaded `ring` test has been modified so it doesn't rely on user input.
- NDEBUG is undefined to allow unit testing in release mode.
- Some `slot_map` warnings were disabled for gcc 7. It freaks out with structured bindings (gcc 8 will catch real c++17 warnings).
- Previous `plf_colony` fixes were reverted. I believe the author ignored them when pushing a new update. They have been reapplied. CI would have caught this ;)
