### PR TITLE
Ci Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # SG14
 [![Build Status](https://travis-ci.org/WG21-SG14/SG14.svg?branch=master)](https://travis-ci.org/WG21-SG14/SG14)
+[![Build status](https://ci.appveyor.com/api/projects/status/5naglxxc9y13lisr?svg=true)](https://ci.appveyor.com/project/p-groarke/sg14)
 
 A library for Study Group 14 of Working Group 21 (C++)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+image:
+  - Visual Studio 2017
+platform:
+  - x64
+configuration:
+  - Debug
+  - Release
+clone_folder: c:\projects\sg14
+before_build:
+  - cmd: cd c:\projects\sg14 & mkdir build & cd build & cmake .. -A x64"
+build:
+  project: c:\projects\sg14\build\sg14.sln
+  parallel: true
+test_script:
+  - cmd: c:\projects\sg14\build\bin\sg14_tests.exe


### PR DESCRIPTION
Adds AppVeyor CI for MSVC 2017.

As with travis CI, this will require an AppVeyor account. I will update the badge once we get it.