### PR TITLE
slot_map : DRY, container access and cleanup.

### DIFF
--- a/SG14/slot_map.h
+++ b/SG14/slot_map.h
@@ -114,11 +114,7 @@ public:
     // O(1) time and space complexity.
     //
     constexpr reference at(const key_type& key) {
-        auto value_iter = this->find(key);
-        if (value_iter == this->end()) {
-            SLOT_MAP_THROW_EXCEPTION(std::out_of_range, "at");
-        }
-        return *value_iter;
+        return const_cast<reference>(static_cast<const slot_map*>(this)->at(key));
     }
     constexpr const_reference at(const key_type& key) const {
         auto value_iter = this->find(key);
@@ -132,24 +128,20 @@ public:
     // If the check fails it is undefined behavior.
     // O(1) time and space complexity.
     //
-    constexpr reference operator[](const key_type& key)              { return *find_unchecked(key); }
-    constexpr const_reference operator[](const key_type& key) const  { return *find_unchecked(key); }
+    constexpr reference operator[](const key_type& key) {
+        return const_cast<reference>(static_cast<const slot_map*>(this)->operator [](key));
+    }
+    constexpr const_reference operator[](const key_type& key) const {
+        return *find_unchecked(key);
+    }
 
     // The find() functions have generation counter checking.
     // If the check fails, the result of end() is returned.
     // O(1) time and space complexity.
     //
     constexpr iterator find(const key_type& key) {
-        auto slot_index = get_index(key);
-        if (slot_index >= slots_.size()) {
-            return end();
-        }
-        auto slot_iter = std::next(slots_.begin(), slot_index);
-        if (get_generation(*slot_iter) != get_generation(key)) {
-            return end();
-        }
-        auto value_iter = std::next(values_.begin(), get_index(*slot_iter));
-        return value_iter;
+        const_iterator it = static_cast<const slot_map*>(this)->find(key);
+        return values_.erase(it, it);
     }
     constexpr const_iterator find(const key_type& key) const {
         auto slot_index = get_index(key);
@@ -168,9 +160,8 @@ public:
     // O(1) time and space complexity.
     //
     constexpr iterator find_unchecked(const key_type& key) {
-        auto slot_iter = std::next(slots_.begin(), get_index(key));
-        auto value_iter = std::next(values_.begin(), get_index(*slot_iter));
-        return value_iter;
+        const_iterator it = static_cast<const slot_map*>(this)->find_unchecked(key);
+        return values_.erase(it, it);
     }
     constexpr const_iterator find_unchecked(const key_type& key) const {
         auto slot_iter = std::next(slots_.begin(), get_index(key));

--- a/SG14/slot_map.h
+++ b/SG14/slot_map.h
@@ -295,13 +295,12 @@ public:
         swap(next_available_slot_index_, rhs.next_available_slot_index_);
     }
 
-protected:
     // These accessors are not part of P0661R2 but are "modernized" versions
     // of the protected interface of std::priority_queue, std::stack, etc.
-    constexpr Container<mapped_type>& c() & noexcept { return values_; }
-    constexpr const Container<mapped_type>& c() const& noexcept { return values_; }
-    constexpr Container<mapped_type>&& c() && noexcept { return std::move(values_); }
-    constexpr const Container<mapped_type>&& c() const&& noexcept { return std::move(values_); }
+    constexpr Container<mapped_type>& container() & noexcept { return values_; }
+    constexpr const Container<mapped_type>& container() const& noexcept { return values_; }
+    constexpr Container<mapped_type>&& container() && noexcept { return std::move(values_); }
+    constexpr const Container<mapped_type>&& container() const&& noexcept { return std::move(values_); }
 
 private:
     constexpr slot_iterator slot_iter_from_value_iter(const_iterator value_iter) {

--- a/SG14_test/slot_map_test.cpp
+++ b/SG14_test/slot_map_test.cpp
@@ -86,6 +86,24 @@ struct Vector {
         a = std::move(b);
         b = std::move(t);
     }
+    iterator erase(const_iterator first, const_iterator last) {
+        assert(first <= last && "vector erase iterator outside range");
+        size_t delta = last - first;
+        iterator data_beg = &data_[first - begin()];
+        if (delta == 0) {
+            return data_beg;
+        }
+        iterator data_end = data_beg + delta;
+        iterator it = data_beg;
+        while (it != data_end) {
+            it->~T();
+            ++it;
+        }
+        iterator new_end = end() - delta;
+        std::swap_ranges(data_beg, data_end, new_end);
+        size_ -= delta;
+        return begin() + size_;
+    }
 private:
     size_t size_ = 0;
     std::unique_ptr<T[]> data_ = nullptr;

--- a/SG14_test/slot_map_test.cpp
+++ b/SG14_test/slot_map_test.cpp
@@ -1,12 +1,12 @@
 #include "SG14_test.h"
 #include "slot_map.h"
-#include <assert.h>
-#include <inttypes.h>
 #include <algorithm>
+#include <assert.h>
 #include <deque>
 #include <forward_list>
-#include <list>
+#include <inttypes.h>
 #include <iterator>
+#include <list>
 #include <memory>
 #include <random>
 #include <type_traits>


### PR DESCRIPTION
@Quuxplusone 
To prevent issues like the const find out-of-range access that happen recently, use dry best practices. I didn't use the const_cast technique for one-liner getters. Happy to add that if you want it.

Make container access public, it is required for C interop.