### PR TITLE
TravisCI Win32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,14 @@ before_install:
 
 matrix:
   include:
+    - os: windows
+      env:
+        - CONFIG=Release
+
+    - os: windows
+      env:
+        - CONFIG=Debug
+
     - os: osx
       osx_image: xcode9.2
       env:

--- a/SG14/inplace_function.h
+++ b/SG14/inplace_function.h
@@ -36,7 +36,9 @@ namespace inplace_function_detail {
 
 static constexpr size_t InplaceFunctionDefaultCapacity = 32;
 
-#if defined(__GLIBCXX__)  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61458
+#if defined(__GLIBCXX__) || defined(_MSVC_STL_VERSION)
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61458
+// MSVC 32-bit has the same bug.
 template<size_t Cap>
 union aligned_storage_helper {
     struct double1 { double a; };
@@ -60,9 +62,13 @@ struct aligned_storage {
 
 template<size_t Cap, size_t Align = std::alignment_of<aligned_storage_helper<Cap>>::value>
 using aligned_storage_t = typename aligned_storage<Cap, Align>::type;
+static_assert(sizeof(aligned_storage_t<sizeof(void*)>) == sizeof(void*), "A");
+static_assert(alignof(aligned_storage_t<sizeof(void*)>) == alignof(void*), "B");
 #else
 using std::aligned_storage;
 using std::aligned_storage_t;
+static_assert(sizeof(std::aligned_storage_t<sizeof(void*)>) == sizeof(void*), "C");
+static_assert(alignof(std::aligned_storage_t<sizeof(void*)>) == alignof(void*), "D");
 #endif
 
 template<typename T> struct wrapper

--- a/SG14_test/inplace_function_test.cpp
+++ b/SG14_test/inplace_function_test.cpp
@@ -336,11 +336,7 @@ constexpr size_t expected_alignment_for_capacity()
     constexpr size_t alignof_cap = std::alignment_of<std::aligned_storage_t<Cap>>::value;
 #define MIN(a,b) (a < b ? a : b)
 #define MAX(a,b) (a > b ? a : b)
-#if defined(__GLIBCXX__)  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61458
     return MAX(MIN(Cap, alignof_cap), alignof_ptr);
-#else  // other STLs
-    return MAX(alignof_cap, alignof_ptr);
-#endif
 #undef MAX
 #undef MIN
 }


### PR DESCRIPTION
(ping @Voultapher @carlcook @p-groarke)

commit f6171d309495c75db2f4e4bf9c188c3e86f6223a

    Add TravisCI's new Windows integration!
    
    This is Win32 only for now. To get a Win64 build, I think we have to
    add `-A 64` to the cmake command line, and I don't know how to do that.
    Someone else can figure that out.

commit d614e1bf606d49ec112a7348223071eba0eb03bb

    Stop using std::aligned_storage. Stop using std::alignment_of.
    
    The former is wrong more often than it's right, so let's just
    switch to our hand-rolled, 100% correct implementation and get rid
    of the hard-to-maintain ifdefs.
    
    The latter is obsolete compared to the `alignof` keyword, and
    just ends up making lots of template instantiations that we
    don't need to be paying for.

Thanks to @ThomasFeher for bringing this new Travis feature to my attention!