### PR TITLE
Slot map - Add unit tests, conform operator[]() to comment, add at_unchecked(), add key()

### DIFF
--- a/SG14/slot_map.h
+++ b/SG14/slot_map.h
@@ -128,17 +128,6 @@ public:
         return *value_iter;
     }
 
-    // The at_unchecked() function has no checks whatsoever
-    // and does not throw.
-    // O(1) time and space complexity.
-    //
-    constexpr reference at_unchecked(const key_type& key) {
-        return *find_unchecked(key);
-    }
-    constexpr const_reference at_unchecked(const key_type& key) const {
-        return *find_unchecked(key);
-    }
-
     // The bracket operator[] has a generation counter check
     // and does not throw.
     // If the check fails it is undefined behavior.

--- a/SG14_test/slot_map_test.cpp
+++ b/SG14_test/slot_map_test.cpp
@@ -17,20 +17,22 @@ namespace TestKey {
 struct key_16_8_t {
     uint16_t index;
     uint8_t generation;
-    friend bool operator==(key_16_8_t lhs, key_16_8_t rhs);
+
+    // For unit tests only, not a necessary user API.
+    friend bool operator==(key_16_8_t lhs, key_16_8_t rhs) {
+        return lhs.index == rhs.index && lhs.generation == rhs.generation;
+    }
 };
-bool operator==(key_16_8_t lhs, key_16_8_t rhs) {
-    return lhs.index == rhs.index && lhs.generation == rhs.generation;
-}
 
 struct key_11_5_t {  // C++17 only
     uint16_t index : 11;
     uint8_t generation : 5;
-    friend bool operator==(key_11_5_t lhs, key_11_5_t rhs);
+
+    // For unit tests only, not a necessary user API.
+    friend bool operator==(key_11_5_t lhs, key_11_5_t rhs) {
+        return lhs.index == rhs.index && lhs.generation == rhs.generation;
+    }
 };
-bool operator==(key_11_5_t lhs, key_11_5_t rhs) {
-    return lhs.index == rhs.index && lhs.generation == rhs.generation;
-}
 
 #if __cplusplus < 201703L
 template<int I, class K> auto get(const K& k) { return get(k, std::integral_constant<int, I>{}); }

--- a/SG14_test/slot_map_test.cpp
+++ b/SG14_test/slot_map_test.cpp
@@ -162,13 +162,11 @@ static void BasicTests(T t1, T t2)
     assert(sm.find_unchecked(k1) == sm.begin());
     assert(sm[k1] == *sm.begin());
     assert(sm.at(k1) == *sm.begin());
-    assert(sm.at_unchecked(k1) == *sm.begin());
 
     assert(sm.find(k2) == std::next(sm.begin()));
     assert(sm.find_unchecked(k2) == std::next(sm.begin()));
     assert(sm[k2] == *std::next(sm.begin()));
     assert(sm.at(k2) == *std::next(sm.begin()));
-    assert(sm.at_unchecked(k2) == *std::next(sm.begin()));
 
     assert(sm2.empty());
     assert(sm2.size() == 0);
@@ -193,7 +191,6 @@ static void BasicTests(T t1, T t2)
     assert(sm2.find_unchecked(k2) == sm2.begin());  // find a non-expired key
     assert(sm2[k2] == *sm2.begin());  // find a non-expired key
     assert(sm2.at(k2) == *sm2.begin());  // find a non-expired key
-    assert(sm2.at_unchecked(k2) == *sm2.begin());  // find a non-expired key
 
     assert(sm2.erase(k1) == 0);  // erase an expired key
 }


### PR DESCRIPTION
- Adds a few missing unit tests.

- `operator[]` didn't conform to the comment. Moved completely unchecked behavior to `at_unchecked` and modified `operator[]` to match comment. It has a generation check, but no out-of-bounds check.

- As mentioned in https://github.com/WG21-SG14/SG14/issues/141, add a key api to find the key of a given element.

- Renamed `key_size_type` to `key_index_type`.