### PR TITLE
slot_map : Fix generation skipping.

### DIFF
--- a/SG14/slot_map.h
+++ b/SG14/slot_map.h
@@ -247,7 +247,6 @@ public:
         auto slot_iter = std::next(slots_.begin(), next_available_slot_index_);
         next_available_slot_index_ = this->get_index(*slot_iter);
         this->set_index(*slot_iter, value_pos);
-        this->increment_generation(*slot_iter);
         key_type result = *slot_iter;
         this->set_index(result, std::distance(slots_.begin(), slot_iter));
         return result;


### PR DESCRIPTION
Slot generation was being incremented both on slot free and on element
insertion. Effectively halving key generation space.