### PR TITLE
Add installation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ link_directories(${CMAKE_CURRENT_BINARY_DIR}/lib) # For future use with testing 
 ##
 add_library(${PROJECT_NAME} INTERFACE)
 
+include(GNUInstallDirs)
 
 target_include_directories(${PROJECT_NAME} INTERFACE
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
@@ -79,13 +80,11 @@ endif()
 
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}_targets)
 
-include(GNUInstallDirs)
-
 install(EXPORT ${PROJECT_NAME}_targets
     NAMESPACE ${PROJECT_NAME}::
     FILE ${PROJECT_NAME}-config.cmake
     DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
 )
 
-install(DIRECTORY "${PROJECT_SOURCE_DIR}/SG14" DESTINATION include)
+install(DIRECTORY "${SG14_INCLUDE_DIRECTORY}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,13 +28,9 @@ link_directories(${CMAKE_CURRENT_BINARY_DIR}/lib) # For future use with testing 
 ##
 # Project
 ##
-file(GLOB_RECURSE INCLUDES "${SG14_INCLUDE_DIRECTORY}/*.hpp" "${SG14_INCLUDE_DIRECTORY}/*.h")
 add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME} INTERFACE ${SG14_INCLUDE_DIRECTORY})
-target_sources(${PROJECT_NAME} INTERFACE
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-	$<BUILD_INTERFACE:${INCLUDES}>
-)
+
+
 target_include_directories(${PROJECT_NAME} INTERFACE
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 	$<BUILD_INTERFACE:${SG14_INCLUDE_DIRECTORY}>
@@ -80,3 +76,16 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	set_source_files_properties(${SG14_TEST_SOURCE_DIRECTORY}/plf_colony_test.cpp PROPERTIES
 		COMPILE_FLAGS "/wd4127") # Disable conditional expression is constant, use if constexpr
 endif()
+
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}_targets)
+
+include(GNUInstallDirs)
+
+install(EXPORT ${PROJECT_NAME}_targets
+    NAMESPACE ${PROJECT_NAME}::
+    FILE ${PROJECT_NAME}-config.cmake
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}"
+)
+
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/SG14" DESTINATION include)
+


### PR DESCRIPTION
These changes provide minimal CMake installation support.
This way consumers can install the headers and reuse accross projects without having to
copy them in each project independently. 

With these changes it will also be possible to add vcpkg and conan support with minimal efford allowing teams that depend on these package managers to more easily use the library.

A note on the following removed lines:

```
-file(GLOB_RECURSE INCLUDES "${SG14_INCLUDE_DIRECTORY}/*.hpp" "${SG14_INCLUDE_DIRECTORY}/*.h")
-target_include_directories(${PROJECT_NAME} INTERFACE ${SG14_INCLUDE_DIRECTORY})
-target_sources(${PROJECT_NAME} INTERFACE
-       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-       $<BUILD_INTERFACE:${INCLUDES}>
-)

```
`target_sources` is not needed in interface libraries supplying header files since these will be appended to the target's sources to be built. However these will be ignored since cmake does not recognize files ending with `.h` or `.hpp` as source files when building. I also assume that the `target_include_directories` line was simply forgotten since there is a proper invocation a bit later in the script. This one is wrong since it references the source tree in the INTERFACE properties.

Another thing is that the current support requires consumer packages to prefix the headers with SG14 when including. This is good practice but I also allowed the tests be able to include the headers directly.

Any feedback is welcome!